### PR TITLE
Refactor/improve type support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,25 @@ Library to simplify querying Kubernetes objects
 
 # Usage
 
-First select if you want to query cluster level objects or namespaced objects
+First create the client and configure it
 
 ```go
-client := simplekube.NewClient(ctx, clientset)
-clusterQuery := client.ClusterQuery()
-namespacedQuery := client.NamespacedQuery(namespace)
+client := sk.Client{}
+client.Config(ctx, clientset)
 ```
 
-Then you can choose one of the following actions:
+This gives basic cluster level objects, for example creating a new namespace:
+
+```go
+ns := skcl.Namespace{ Name: "my-namespace" }
+err := client.Namespace().Create(ns).Run()
+```
+
+Note: skcl being "github.com/ilexPar/simple-kube/pkg/cluster/resources"
+
+## Resource Actions
+
+These are valid resource actions for each resource:
 
 - Get
 - List
@@ -22,13 +32,15 @@ Then you can choose one of the following actions:
 
 Select any aditional options for your query and then call `Run()`
 
-For  example:
+In this example we list Cronjobs in "my-namespace" filtered by a map of labels:
+
 ```go
 filter := map[string]string{"key": "value"}
-cronjobs, err := namespacedQuery.CronJob().
-    List().
-    FilterByLabels(filter).
-    Run()
+cronjobs, err := client.InNamespace("my-ns").
+		CronJob().
+		List().
+		FilterByLabels(filter).
+		Run()
 ```
 
 # Advanced usage
@@ -46,11 +58,12 @@ Example:
 
 ```go
 // Create a CronJob with a custom termination grace period
-cron, err := namespacedQuery.CronJob().Get("my-cron").
-    DataHandler(func(obj interface{}) error {
-        kc := res.(*batch.CronJob)
+cron, err := client.InNamespace("my-ns").
+		CronJob().
+		Get("my-cron").
+		DataHandler(func(cronjob *batch.CronJob) error {
         grace := int64(10)
-        kc.Spec.JobTemplate.Spec.Template.Spec.TerminationGracePeriodSeconds = grace
+        cronjob.Spec.JobTemplate.Spec.Template.Spec.TerminationGracePeriodSeconds = grace
         return nil
     })
 ```

--- a/pkg/base/types.go
+++ b/pkg/base/types.go
@@ -1,6 +1,11 @@
 package base
 
 import (
+	apps "k8s.io/api/apps/v1"
+	scaling "k8s.io/api/autoscaling/v2"
+	batch "k8s.io/api/batch/v1"
+	api "k8s.io/api/core/v1"
+	net "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -11,4 +16,8 @@ type QueryOpts struct {
 type ResourceInterface interface {
 	Load(from, into interface{}) error
 	Dump(from interface{}) (interface{}, error)
+}
+
+type KubernetesResources interface {
+	apps.Deployment | api.ConfigMap | api.Service | batch.Job | batch.CronJob | net.Ingress | scaling.HorizontalPodAutoscaler
 }

--- a/pkg/base/utils.go
+++ b/pkg/base/utils.go
@@ -16,3 +16,16 @@ func FlattenLabels(labels map[string]string) string {
 	}
 	return flatLabels
 }
+
+func Cast[T any](obj interface{}) (T, error) {
+	if obj == nil {
+		var zero T
+		return zero, fmt.Errorf("cannot cast nil to %T", zero)
+	}
+	val, ok := obj.(T)
+	if !ok {
+		var zero T
+		return zero, fmt.Errorf("cannot cast %T to %T", obj, zero)
+	}
+	return val, nil
+}

--- a/pkg/cluster/main.go
+++ b/pkg/cluster/main.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/ilexPar/simple-kube/pkg/base"
 	"github.com/ilexPar/simple-kube/pkg/cluster/resources"
@@ -62,16 +63,15 @@ func (ca *Action[T]) Delete(resource string) ClusterDeleteInterface[T] {
 	}
 }
 
-func NewQuery(ctx context.Context, client kubernetes.Interface) *Query {
-	return &Query{
-		ctx:    ctx,
-		client: client,
-	}
-}
-
 type Query struct {
 	ctx    context.Context
 	client kubernetes.Interface
+}
+
+func (c *Query) Config(ctx context.Context, client kubernetes.Interface) *Query {
+	c.ctx = ctx
+	c.client = client
+	return c
 }
 
 func (c *Query) getResourceAPI(
@@ -83,6 +83,7 @@ func (c *Query) getResourceAPI(
 }
 
 func (c *Query) Namespace() ClusterAction[resources.Namespace] {
+	fmt.Printf("this is me query %v", c)
 	res := resources.Namespace{}
 	return NewClusterAction(
 		res,

--- a/pkg/main.go
+++ b/pkg/main.go
@@ -58,31 +58,25 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
+type clusterQuery = *cluster.Query
+
 type Client struct {
 	ctx    context.Context
 	client kubernetes.Interface
+	clusterQuery
 }
 
-func NewClient(ctx context.Context, client kubernetes.Interface) *Client {
-	return &Client{
-		ctx:    ctx,
-		client: client,
-	}
+func (c *Client) Config(ctx context.Context, client kubernetes.Interface) *Client {
+	query := (&cluster.Query{}).Config(ctx, client)
+	c.clusterQuery = query
+	c.ctx = ctx
+	c.client = client
+	return c
 }
 
-func (c *Client) NamespacedQuery(
+func (c *Client) InNamespace(
 	namespace string,
 ) namespaced.QueryNamespace {
-	return namespaced.NewQuery(
-		namespace,
-		c.ctx,
-		c.client,
-	)
-}
-
-func (c *Client) ClusterQuery() cluster.QueryCluster {
-	return cluster.NewQuery(
-		c.ctx,
-		c.client,
-	)
+	query := (&namespaced.Query{}).Config(c.ctx, c.client, namespace)
+	return query
 }

--- a/pkg/main.go
+++ b/pkg/main.go
@@ -2,13 +2,21 @@
 //
 // # Usage
 //
-// First select if you want to query cluster level objects or namespaced objects
+// First create the client and configure it:
 //
-//	client := simplekube.NewClient(ctx, clientset)
-//	clusterQuery := client.ClusterQuery()
-//	namespacedQuery := client.NamespacedQuery(namespace)
+//	client := simplekube.Client{}
+//	client.Config(ctx, clientset)
 //
-// Then you can choose one of the following actions:
+// This gives basic cluster level objects, for example creating a new namespace:
+//
+//	ns := skcl.Namespace{ Name: "my-namespace" }
+//	err := client.Namespace().Create(ns).Run()
+//
+// Note: skcl being "github.com/ilexPar/simple-kube/pkg/cluster/resources"
+//
+// ## Resource Actions
+//
+// These are valid resource actions for each resource:
 //
 // - Get
 // - List
@@ -18,13 +26,14 @@
 //
 // Select any aditional options for your query and then call `Run()`
 //
-// For  example:
+// In this example we list Cronjobs in "my-namespace" filtered by a map of labels:
 //
-//	 filter := map[string]string{"key": "value"}
-//	 cronjobs, err := namespacedQuery.CronJob().
-//	 	List().
-//		FilterByLabels(filter).
-//		Run()
+//	filter := map[string]string{"key": "value"}
+//	cronjobs, err := client.InNamespace("my-ns").
+//	  CronJob().
+//	  List().
+//	  FilterByLabels(filter).
+//	  Run()
 //
 // # Advanced usage
 //
@@ -40,13 +49,15 @@
 // Example:
 //
 //	// Create a CronJob with a custom termination grace period
-//	cron, err := namespacedQuery.CronJob().Get("my-cron").
-//		DataHandler(func(obj interface{}) error {
-//			kc := res.(*batch.CronJob)
-//			grace := int64(10)
-//			kc.Spec.JobTemplate.Spec.Template.Spec.TerminationGracePeriodSeconds = grace
-//			return nil
-//		})
+//	cron, err := client.InNamespace("my-namespace").
+//	  CronJob().
+//	  Get("my-cron").
+//	  DataHandler(func(cronjob *batch.CronJob) error {
+//	    grace := int64(10)
+//	    cronjob.Spec.JobTemplate.Spec.Template.Spec.TerminationGracePeriodSeconds = grace
+//	    return nil
+//	  }).
+//	  Run()
 package simplekube
 
 import (

--- a/pkg/namespaced/create.go
+++ b/pkg/namespaced/create.go
@@ -1,13 +1,19 @@
 package namespaced
 
-type NamespacedCreate[T NamespacedResources] struct {
-	Action[T]
+import (
+	"github.com/ilexPar/simple-kube/pkg/base"
+	sm "github.com/ilexPar/struct-marshal/pkg"
+)
+
+type NamespacedCreate[T NamespacedResources, R base.KubernetesResources] struct {
+	Action[T, R]
 	Resource T
-	callback func(interface{}) error
+	callback func(*R) error
 }
 
-func (c *NamespacedCreate[T]) Run() error {
-	obj, err := c.Resource.Dump(c.Resource)
+func (c *NamespacedCreate[T, R]) Run() error {
+	obj := new(R)
+	err := sm.Marshal(c.Resource, obj)
 	if err != nil {
 		return err
 	}
@@ -22,9 +28,9 @@ func (c *NamespacedCreate[T]) Run() error {
 	return err
 }
 
-func (c *NamespacedCreate[T]) DataHandler(
-	handler func(interface{}) error,
-) NamespacedPutInterface[T] {
+func (c *NamespacedCreate[T, R]) DataHandler(
+	handler func(*R) error,
+) NamespacedPutInterface[T, R] {
 	c.callback = handler
 	return c
 }

--- a/pkg/namespaced/delete.go
+++ b/pkg/namespaced/delete.go
@@ -1,10 +1,12 @@
 package namespaced
 
-type NamespacedDelete[T NamespacedResources] struct {
-	Action[T]
+import "github.com/ilexPar/simple-kube/pkg/base"
+
+type NamespacedDelete[T NamespacedResources, R base.KubernetesResources] struct {
+	Action[T, R]
 	Id string
 }
 
-func (d *NamespacedDelete[T]) Run() error {
+func (d *NamespacedDelete[T, R]) Run() error {
 	return d.api.Delete(d.Id, d.namespace)
 }

--- a/pkg/namespaced/get.go
+++ b/pkg/namespaced/get.go
@@ -1,14 +1,18 @@
 package namespaced
 
-import "github.com/ilexPar/simple-kube/pkg/errors"
+import (
+	"github.com/ilexPar/simple-kube/pkg/base"
+	"github.com/ilexPar/simple-kube/pkg/errors"
+	sm "github.com/ilexPar/struct-marshal/pkg"
+)
 
-type NamespacedGet[T NamespacedResources] struct {
-	Action[T]
+type NamespacedGet[T NamespacedResources, R base.KubernetesResources] struct {
+	Action[T, R]
 	Id       string
-	callback func(interface{}) error
+	callback func(*R) error
 }
 
-func (g *NamespacedGet[T]) Run() (T, error) {
+func (g *NamespacedGet[T, R]) Run() (T, error) {
 	res := new(T)
 
 	obj, err := g.api.Get(g.Id, g.namespace)
@@ -22,11 +26,11 @@ func (g *NamespacedGet[T]) Run() (T, error) {
 		}
 	}
 
-	err = g.resource.Load(obj, res)
+	err = sm.Unmarshal(obj, res)
 	return *res, err
 }
 
-func (g *NamespacedGet[T]) DataHandler(handler func(interface{}) error) NamespacedGetInterface[T] {
+func (g *NamespacedGet[T, R]) DataHandler(handler func(*R) error) NamespacedGetInterface[T, R] {
 	g.callback = handler
 	return g
 }

--- a/pkg/namespaced/list.go
+++ b/pkg/namespaced/list.go
@@ -2,13 +2,14 @@ package namespaced
 
 import (
 	"github.com/ilexPar/simple-kube/pkg/base"
+	sm "github.com/ilexPar/struct-marshal/pkg"
 )
 
-type NamespacedList[T NamespacedResources] struct {
-	Action[T]
+type NamespacedList[T NamespacedResources, R base.KubernetesResources] struct {
+	Action[T, R]
 }
 
-func (l *NamespacedList[T]) Run() ([]T, error) {
+func (l *NamespacedList[T, R]) Run() ([]T, error) {
 	res := []T{}
 	l.api.SetOpts(l.opts)
 	objs, err := l.api.List(l.namespace)
@@ -17,7 +18,7 @@ func (l *NamespacedList[T]) Run() ([]T, error) {
 	}
 	for _, obj := range objs {
 		resource := new(T)
-		if err = l.resource.Load(obj, resource); err != nil {
+		if err = sm.Unmarshal(obj, resource); err != nil {
 			return res, err
 		}
 		res = append(res, *resource)
@@ -26,7 +27,7 @@ func (l *NamespacedList[T]) Run() ([]T, error) {
 	return res, err
 }
 
-func (l *NamespacedList[T]) FilterByLabels(labels map[string]string) NamespacedListInterface[T] {
+func (l *NamespacedList[T, R]) FilterByLabels(labels map[string]string) NamespacedListInterface[T, R] {
 	l.opts.List.LabelSelector = base.FlattenLabels(labels)
 	return l
 }

--- a/pkg/namespaced/main.go
+++ b/pkg/namespaced/main.go
@@ -71,22 +71,21 @@ func (ns *Action[T, R]) Delete(resource string) NamespacedDeleteInterface[T, R] 
 	}
 }
 
-func NewQuery(
-	namespace string,
-	ctx context.Context,
-	client kubernetes.Interface,
-) *Query {
-	return &Query{
-		namespace: namespace,
-		ctx:       ctx,
-		client:    client,
-	}
-}
-
 type Query struct {
-	namespace string
 	ctx       context.Context
 	client    kubernetes.Interface
+	namespace string
+}
+
+func (c *Query) Config(
+	ctx context.Context,
+	client kubernetes.Interface,
+	namespace string,
+) *Query {
+	c.ctx = ctx
+	c.client = client
+	c.namespace = namespace
+	return c
 }
 
 func GetNamespacedAPI[R base.KubernetesResources, T NamespacedResources](ctx context.Context, client kubernetes.Interface, res T) skns.NamespacedResourceAPI[R] {

--- a/pkg/namespaced/main.go
+++ b/pkg/namespaced/main.go
@@ -87,7 +87,27 @@ type Query struct {
 func (n *Query) getResourceAPI(
 	res NamespacedResourceMethods,
 ) skns.NamespacedResourceAPI {
-	api := res.API()
+	var api skns.NamespacedResourceAPI
+
+	switch res.(type) {
+	case skns.Deployment:
+		api = &skns.DeploymentAPI{}
+	case skns.Service:
+		api = &skns.ServiceAPI{}
+	case skns.Job:
+		api = &skns.JobAPI{}
+	case skns.CronJob:
+		api = &skns.CronJobAPI{}
+	case skns.ConfigMap:
+		api = &skns.ConfigMapAPI{}
+	case skns.Ingress:
+		api = &skns.IngressAPI{}
+	case skns.HPA:
+		api = &skns.HPAapi{}
+	default:
+		panic("cannot resolve Kube API")
+	}
+
 	api.Config(n.ctx, n.client)
 	return api
 }

--- a/pkg/namespaced/main.go
+++ b/pkg/namespaced/main.go
@@ -7,60 +7,65 @@ import (
 	"github.com/ilexPar/simple-kube/pkg/namespaced/resources"
 	skns "github.com/ilexPar/simple-kube/pkg/namespaced/resources"
 
+	apps "k8s.io/api/apps/v1"
+	scaling "k8s.io/api/autoscaling/v2"
+	batch "k8s.io/api/batch/v1"
+	api "k8s.io/api/core/v1"
+	net "k8s.io/api/networking/v1"
 	"k8s.io/client-go/kubernetes"
 )
 
-type Action[T NamespacedResources] struct {
+type Action[T NamespacedResources, R base.KubernetesResources] struct {
 	namespace string
 	resource  T
-	api       resources.NamespacedResourceAPI
+	api       resources.NamespacedResourceAPI[R]
 	opts      base.QueryOpts
 }
 
-func NewAction[T NamespacedResources](
+func NewAction[R base.KubernetesResources, T NamespacedResources](
 	namespace string,
 	resource T,
-	api resources.NamespacedResourceAPI,
-) *Action[T] {
-	return &Action[T]{
+	api resources.NamespacedResourceAPI[R],
+) *Action[T, R] {
+	return &Action[T, R]{
 		namespace: namespace,
 		resource:  resource,
 		api:       api,
 	}
 }
 
-func (ns *Action[T]) Get(name string) NamespacedGetInterface[T] {
-	return &NamespacedGet[T]{
+func (ns *Action[T, R]) Get(name string) NamespacedGetInterface[T, R] {
+	return &NamespacedGet[T, R]{
 		*ns,
 		name,
 		nil,
 	}
 }
 
-func (ns *Action[T]) Create(resource T) NamespacedPutInterface[T] {
-	return &NamespacedCreate[T]{
+func (ns *Action[T, R]) Create(resource T) NamespacedPutInterface[T, R] {
+	return &NamespacedCreate[T, R]{
 		*ns,
 		resource,
 		nil,
 	}
 }
 
-func (ns *Action[T]) Update(resource T) NamespacedPutInterface[T] {
-	return &NamespacedUpdate[T]{
+func (ns *Action[T, R]) Update(resource T) NamespacedPutInterface[T, R] {
+	return &NamespacedUpdate[T, R]{
 		*ns,
 		resource,
 		nil,
 	}
 }
 
-func (ns *Action[T]) List() NamespacedListInterface[T] {
-	return &NamespacedList[T]{
+func (ns *Action[T, R]) List() NamespacedListInterface[T, R] {
+	return &NamespacedList[T, R]{
 		*ns,
 	}
 }
 
-func (ns *Action[T]) Delete(resource string) NamespacedDeleteInterface[T] {
-	return &NamespacedDelete[T]{
+func (ns *Action[T, R]) Delete(resource string) NamespacedDeleteInterface[T, R] {
+	return &NamespacedDelete[T, R]{
 		*ns,
 		resource,
 	}
@@ -84,93 +89,91 @@ type Query struct {
 	client    kubernetes.Interface
 }
 
-func (n *Query) getResourceAPI(
-	res NamespacedResourceMethods,
-) skns.NamespacedResourceAPI {
-	var api skns.NamespacedResourceAPI
+func GetNamespacedAPI[R base.KubernetesResources, T NamespacedResources](ctx context.Context, client kubernetes.Interface, res T) skns.NamespacedResourceAPI[R] {
+	var api skns.NamespacedResourceAPI[R]
 
-	switch res.(type) {
+	switch any(res).(type) {
 	case skns.Deployment:
-		api = &skns.DeploymentAPI{}
+		api = &skns.DeploymentAPI[R]{}
 	case skns.Service:
-		api = &skns.ServiceAPI{}
+		api = &skns.ServiceAPI[R]{}
 	case skns.Job:
-		api = &skns.JobAPI{}
+		api = &skns.JobAPI[R]{}
 	case skns.CronJob:
-		api = &skns.CronJobAPI{}
+		api = &skns.CronJobAPI[R]{}
 	case skns.ConfigMap:
-		api = &skns.ConfigMapAPI{}
+		api = &skns.ConfigMapAPI[R]{}
 	case skns.Ingress:
-		api = &skns.IngressAPI{}
+		api = &skns.IngressAPI[R]{}
 	case skns.HPA:
-		api = &skns.HPAapi{}
+		api = &skns.HPAapi[R]{}
 	default:
 		panic("cannot resolve Kube API")
 	}
 
-	api.Config(n.ctx, n.client)
+	api.Config(ctx, client)
 	return api
 }
 
-func (n *Query) Deployment() NamespacedAction[skns.Deployment] {
+func (n *Query) Deployment() NamespacedAction[skns.Deployment, apps.Deployment] {
 	res := skns.Deployment{}
-	return NewAction(
+	return NewAction[apps.Deployment](
 		n.namespace,
 		res,
-		n.getResourceAPI(res),
+		GetNamespacedAPI[apps.Deployment](n.ctx, n.client, res),
 	)
 }
 
-func (n *Query) Service() NamespacedAction[skns.Service] {
+func (n *Query) Service() NamespacedAction[skns.Service, api.Service] {
 	res := skns.Service{}
-	return NewAction(
+	return NewAction[api.Service](
 		n.namespace,
 		res,
-		n.getResourceAPI(res),
+		GetNamespacedAPI[api.Service](n.ctx, n.client, res),
 	)
 }
 
-func (n *Query) Job() NamespacedAction[skns.Job] {
+func (n *Query) Job() NamespacedAction[skns.Job, batch.Job] {
 	res := skns.Job{}
-	return NewAction(
+	return NewAction[batch.Job](
 		n.namespace,
 		res,
-		n.getResourceAPI(res),
+		GetNamespacedAPI[batch.Job](n.ctx, n.client, res),
 	)
 }
 
-func (n *Query) CronJob() NamespacedAction[skns.CronJob] {
+func (n *Query) CronJob() NamespacedAction[skns.CronJob, batch.CronJob] {
 	res := skns.CronJob{}
-	return NewAction(
+	return NewAction[batch.CronJob](
 		n.namespace,
 		res,
-		n.getResourceAPI(res),
+		GetNamespacedAPI[batch.CronJob](n.ctx, n.client, res),
 	)
 }
 
-func (n *Query) ConfigMap() NamespacedAction[skns.ConfigMap] {
+func (n *Query) ConfigMap() NamespacedAction[skns.ConfigMap, api.ConfigMap] {
 	res := skns.ConfigMap{}
-	return NewAction(
+	return NewAction[api.ConfigMap](
 		n.namespace,
 		res,
-		n.getResourceAPI(res),
+		GetNamespacedAPI[api.ConfigMap](n.ctx, n.client, res),
 	)
 }
 
-func (n *Query) Ingress() NamespacedAction[skns.Ingress] {
+func (n *Query) Ingress() NamespacedAction[skns.Ingress, net.Ingress] {
 	res := skns.Ingress{}
-	return NewAction(
+	return NewAction[net.Ingress](
 		n.namespace,
 		res,
-		n.getResourceAPI(res),
+		GetNamespacedAPI[net.Ingress](n.ctx, n.client, res),
 	)
 }
 
-func (n *Query) HPA() NamespacedAction[skns.HPA] {
+func (n *Query) HPA() NamespacedAction[skns.HPA, scaling.HorizontalPodAutoscaler] {
 	res := skns.HPA{}
-	return NewAction(
+	return NewAction[scaling.HorizontalPodAutoscaler](
 		n.namespace,
 		res,
-		n.getResourceAPI(res),
+		GetNamespacedAPI[scaling.HorizontalPodAutoscaler](n.ctx, n.client, res),
 	)
 }

--- a/pkg/namespaced/resources/configmap.go
+++ b/pkg/namespaced/resources/configmap.go
@@ -3,7 +3,6 @@ package resources
 import (
 	"github.com/ilexPar/simple-kube/pkg/base"
 
-	sm "github.com/ilexPar/struct-marshal/pkg"
 	api "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -14,59 +13,66 @@ type ConfigMap struct {
 	Data   map[string]string `sm:"data"`
 }
 
-func (cm ConfigMap) API() NamespacedResourceAPI {
-	return &ConfigMapAPI{}
-}
-
-func (cm ConfigMap) Dump(from interface{}) (interface{}, error) {
-	res := &api.ConfigMap{}
-	err := sm.Marshal(from, res)
-	return res, err
-}
-
-func (cm ConfigMap) Load(from, into interface{}) error {
-	return sm.Unmarshal(from, into)
-}
-
-type ConfigMapAPI struct {
+type ConfigMapAPI[R base.KubernetesResources] struct {
 	base.KubeAPI
 }
 
-func (cm *ConfigMapAPI) Get(name, namespace string) (interface{}, error) {
+func (cm *ConfigMapAPI[R]) Get(name, namespace string) (*R, error) {
 	res, err := cm.Client.CoreV1().
 		ConfigMaps(namespace).
 		Get(cm.Context, name, metav1.GetOptions{})
-	return res, err
+	if err != nil {
+		return nil, err
+	}
+
+	result, err := base.Cast[*R](res)
+	return result, err
 }
 
-func (cm *ConfigMapAPI) Create(namespace string, obj interface{}) error {
-	res := obj.(*api.ConfigMap)
-	_, err := cm.Client.CoreV1().
+func (cm *ConfigMapAPI[R]) Create(namespace string, obj *R) error {
+	res, err := base.Cast[*api.ConfigMap](obj)
+	if err != nil {
+		return err
+	}
+
+	_, err = cm.Client.CoreV1().
 		ConfigMaps(namespace).
 		Create(cm.Context, res, metav1.CreateOptions{})
 	return err
 }
 
-func (cm *ConfigMapAPI) Update(namespace string, obj interface{}) error {
-	res := obj.(*api.ConfigMap)
-	_, err := cm.Client.CoreV1().
+func (cm *ConfigMapAPI[R]) Update(namespace string, obj *R) error {
+	res, err := base.Cast[*api.ConfigMap](obj)
+	if err != nil {
+		return err
+	}
+
+	_, err = cm.Client.CoreV1().
 		ConfigMaps(namespace).
 		Update(cm.Context, res, metav1.UpdateOptions{})
 	return err
 }
 
-func (cm *ConfigMapAPI) List(namespace string) ([]interface{}, error) {
-	var res []interface{}
+func (cm *ConfigMapAPI[R]) List(namespace string) ([]R, error) {
+	res := []R{}
 	list, err := cm.Client.CoreV1().
 		ConfigMaps(namespace).
 		List(cm.Context, cm.Opts.List)
-	for _, v := range list.Items {
-		res = append(res, v)
+	if err != nil {
+		return nil, err
 	}
+
+	for _, v := range list.Items {
+		item, err := base.Cast[R](v)
+		if err == nil {
+			res = append(res, item)
+		}
+	}
+
 	return res, err
 }
 
-func (cm *ConfigMapAPI) Delete(name, namespace string) error {
+func (cm *ConfigMapAPI[R]) Delete(name, namespace string) error {
 	return cm.Client.CoreV1().
 		ConfigMaps(namespace).
 		Delete(cm.Context, name, metav1.DeleteOptions{})

--- a/pkg/namespaced/resources/cronjob.go
+++ b/pkg/namespaced/resources/cronjob.go
@@ -3,7 +3,6 @@ package resources
 import (
 	"github.com/ilexPar/simple-kube/pkg/base"
 
-	sm "github.com/ilexPar/struct-marshal/pkg"
 	batch "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,59 +26,65 @@ type CronJobBehaviour struct {
 	StartingDeadline int64            `sm:"spec.startingDeadlineSeconds"`
 }
 
-func (cj CronJob) API() NamespacedResourceAPI {
-	return &CronJobAPI{}
-}
-
-func (cj CronJob) Dump(from interface{}) (interface{}, error) {
-	res := &batch.CronJob{}
-	err := sm.Marshal(from, res)
-	return res, err
-}
-
-func (cj CronJob) Load(from, into interface{}) error {
-	return sm.Unmarshal(from, into)
-}
-
-type CronJobAPI struct {
+type CronJobAPI[R base.KubernetesResources] struct {
 	base.KubeAPI
 }
 
-func (cj *CronJobAPI) Get(name, namespace string) (interface{}, error) {
+func (cj *CronJobAPI[R]) Get(name, namespace string) (*R, error) {
 	res, err := cj.Client.BatchV1().
 		CronJobs(namespace).
 		Get(cj.Context, name, metav1.GetOptions{})
-	return res, err
+	if err != nil {
+		return nil, err
+	}
+
+	result, err := base.Cast[*R](res)
+	return result, err
 }
 
-func (cj *CronJobAPI) Create(namespace string, obj interface{}) error {
-	res := obj.(*batch.CronJob)
-	_, err := cj.Client.BatchV1().
+func (cj *CronJobAPI[R]) Create(namespace string, obj *R) error {
+	res, err := base.Cast[*batch.CronJob](obj)
+	if err != nil {
+		return err
+	}
+
+	_, err = cj.Client.BatchV1().
 		CronJobs(namespace).
 		Create(cj.Context, res, metav1.CreateOptions{})
 	return err
 }
 
-func (cj *CronJobAPI) Update(namespace string, obj interface{}) error {
-	res := obj.(*batch.CronJob)
-	_, err := cj.Client.BatchV1().
+func (cj *CronJobAPI[R]) Update(namespace string, obj *R) error {
+	res, err := base.Cast[*batch.CronJob](obj)
+	if err != nil {
+		return err
+	}
+
+	_, err = cj.Client.BatchV1().
 		CronJobs(namespace).
 		Update(cj.Context, res, metav1.UpdateOptions{})
 	return err
 }
 
-func (cj *CronJobAPI) List(namespace string) ([]interface{}, error) {
-	var res []interface{}
+func (cj *CronJobAPI[R]) List(namespace string) ([]R, error) {
+	res := []R{}
 	list, err := cj.Client.BatchV1().
 		CronJobs(namespace).
 		List(cj.Context, cj.Opts.List)
+	if err != nil {
+		return nil, err
+	}
+
 	for _, v := range list.Items {
-		res = append(res, v)
+		item, err := base.Cast[R](v)
+		if err == nil {
+			res = append(res, item)
+		}
 	}
 	return res, err
 }
 
-func (cj *CronJobAPI) Delete(name, namespace string) error {
+func (cj *CronJobAPI[R]) Delete(name, namespace string) error {
 	return cj.Client.BatchV1().
 		CronJobs(namespace).
 		Delete(cj.Context, name, metav1.DeleteOptions{})

--- a/pkg/namespaced/resources/deployment.go
+++ b/pkg/namespaced/resources/deployment.go
@@ -3,7 +3,6 @@ package resources
 import (
 	"github.com/ilexPar/simple-kube/pkg/base"
 
-	sm "github.com/ilexPar/struct-marshal/pkg"
 	apps "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -18,59 +17,65 @@ type Deployment struct {
 	NodeSelector    map[string]string `sm:"spec.template.spec.nodeSelector"`
 }
 
-func (d Deployment) API() NamespacedResourceAPI {
-	return &DeploymentAPI{}
-}
-
-func (d Deployment) Dump(from interface{}) (interface{}, error) {
-	res := &apps.Deployment{}
-	err := sm.Marshal(from, res)
-	return res, err
-}
-
-func (d Deployment) Load(from, into interface{}) error {
-	return sm.Unmarshal(from, into)
-}
-
-type DeploymentAPI struct {
+type DeploymentAPI[R base.KubernetesResources] struct {
 	base.KubeAPI
 }
 
-func (d *DeploymentAPI) Get(name, namespace string) (interface{}, error) {
+func (d *DeploymentAPI[R]) Get(name, namespace string) (*R, error) {
 	res, err := d.Client.AppsV1().
 		Deployments(namespace).
 		Get(d.Context, name, metav1.GetOptions{})
-	return res, err
+	if err != nil {
+		return nil, err
+	}
+
+	result, err := base.Cast[*R](res)
+	return result, err
 }
 
-func (d *DeploymentAPI) Create(namespace string, obj interface{}) error {
-	res := obj.(*apps.Deployment)
-	_, err := d.Client.AppsV1().
+func (d *DeploymentAPI[R]) Create(namespace string, obj *R) error {
+	res, err := base.Cast[*apps.Deployment](obj)
+	if err != nil {
+		return err
+	}
+
+	_, err = d.Client.AppsV1().
 		Deployments(namespace).
 		Create(d.Context, res, metav1.CreateOptions{})
 	return err
 }
 
-func (d *DeploymentAPI) Update(namespace string, obj interface{}) error {
-	res := obj.(*apps.Deployment)
-	_, err := d.Client.AppsV1().
+func (d *DeploymentAPI[R]) Update(namespace string, obj *R) error {
+	res, err := base.Cast[*apps.Deployment](obj)
+	if err != nil {
+		return err
+	}
+
+	_, err = d.Client.AppsV1().
 		Deployments(namespace).
 		Update(d.Context, res, metav1.UpdateOptions{})
 	return err
 }
 
-func (d *DeploymentAPI) List(namespace string) ([]interface{}, error) {
-	var res []interface{}
+func (d *DeploymentAPI[R]) List(namespace string) ([]R, error) {
+	res := []R{}
 	list, err := d.Client.AppsV1().
 		Deployments(namespace).
 		List(d.Context, d.Opts.List)
+	if err != nil {
+		return nil, err
+	}
+
 	for _, v := range list.Items {
-		res = append(res, v)
+		item, err := base.Cast[R](v)
+		if err == nil {
+			res = append(res, item)
+		}
 	}
 	return res, err
 }
 
-func (d *DeploymentAPI) Delete(name, namespace string) error {
+func (d *DeploymentAPI[R]) Delete(name, namespace string) error {
 	return d.Client.AppsV1().
 		Deployments(namespace).
 		Delete(d.Context, name, metav1.DeleteOptions{})

--- a/pkg/namespaced/resources/hpa.go
+++ b/pkg/namespaced/resources/hpa.go
@@ -2,7 +2,6 @@ package resources
 
 import (
 	"github.com/ilexPar/simple-kube/pkg/base"
-	sm "github.com/ilexPar/struct-marshal/pkg"
 	scaling "k8s.io/api/autoscaling/v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -32,59 +31,65 @@ type HPAResourceMetric struct {
 	Utilization int                      `sm:"target.averageUtilization"`
 }
 
-func (h HPA) API() NamespacedResourceAPI {
-	return &HPAapi{}
-}
-
-func (h HPA) Dump(from interface{}) (interface{}, error) {
-	res := &scaling.HorizontalPodAutoscaler{}
-	err := sm.Marshal(from, res)
-	return res, err
-}
-
-func (h HPA) Load(from, into interface{}) error {
-	return sm.Unmarshal(from, into)
-}
-
-type HPAapi struct {
+type HPAapi[R base.KubernetesResources] struct {
 	base.KubeAPI
 }
 
-func (h *HPAapi) Get(name, namespace string) (interface{}, error) {
+func (h *HPAapi[R]) Get(name, namespace string) (*R, error) {
 	res, err := h.Client.AutoscalingV2().
 		HorizontalPodAutoscalers(namespace).
 		Get(h.Context, name, metav1.GetOptions{})
-	return res, err
+	if err != nil {
+		return nil, err
+	}
+
+	result, err := base.Cast[*R](res)
+	return result, err
 }
 
-func (h *HPAapi) Create(namespace string, obj interface{}) error {
-	res := obj.(*scaling.HorizontalPodAutoscaler)
-	_, err := h.Client.AutoscalingV2().
+func (h *HPAapi[R]) Create(namespace string, obj *R) error {
+	res, err := base.Cast[*scaling.HorizontalPodAutoscaler](obj)
+	if err != nil {
+		return err
+	}
+
+	_, err = h.Client.AutoscalingV2().
 		HorizontalPodAutoscalers(namespace).
 		Create(h.Context, res, metav1.CreateOptions{})
 	return err
 }
 
-func (h *HPAapi) Update(namespace string, obj interface{}) error {
-	res := obj.(*scaling.HorizontalPodAutoscaler)
-	_, err := h.Client.AutoscalingV2().
+func (h *HPAapi[R]) Update(namespace string, obj *R) error {
+	res, err := base.Cast[*scaling.HorizontalPodAutoscaler](obj)
+	if err != nil {
+		return err
+	}
+
+	_, err = h.Client.AutoscalingV2().
 		HorizontalPodAutoscalers(namespace).
 		Update(h.Context, res, metav1.UpdateOptions{})
 	return err
 }
 
-func (h *HPAapi) List(namespace string) ([]interface{}, error) {
-	var res []interface{}
+func (h *HPAapi[R]) List(namespace string) ([]R, error) {
+	res := []R{}
 	list, err := h.Client.AutoscalingV2().
 		HorizontalPodAutoscalers(namespace).
 		List(h.Context, h.Opts.List)
+	if err != nil {
+		return nil, err
+	}
+
 	for _, v := range list.Items {
-		res = append(res, v)
+		item, err := base.Cast[R](v)
+		if err == nil {
+			res = append(res, item)
+		}
 	}
 	return res, err
 }
 
-func (h *HPAapi) Delete(name, namespace string) error {
+func (h *HPAapi[R]) Delete(name, namespace string) error {
 	return h.Client.AutoscalingV2().
 		HorizontalPodAutoscalers(namespace).
 		Delete(h.Context, name, metav1.DeleteOptions{})

--- a/pkg/namespaced/resources/ingress.go
+++ b/pkg/namespaced/resources/ingress.go
@@ -3,7 +3,6 @@ package resources
 import (
 	"github.com/ilexPar/simple-kube/pkg/base"
 
-	sm "github.com/ilexPar/struct-marshal/pkg"
 	net "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -22,59 +21,65 @@ type IngressPathDef struct {
 	Port    int          `sm:"backend.service.port.number"`
 }
 
-func (i Ingress) API() NamespacedResourceAPI {
-	return &IngressAPI{}
-}
-
-func (i Ingress) Dump(from interface{}) (interface{}, error) {
-	res := &net.Ingress{}
-	err := sm.Marshal(from, res)
-	return res, err
-}
-
-func (i Ingress) Load(from, into interface{}) error {
-	return sm.Unmarshal(from, into)
-}
-
-type IngressAPI struct {
+type IngressAPI[R base.KubernetesResources] struct {
 	base.KubeAPI
 }
 
-func (i *IngressAPI) Get(name, namespace string) (interface{}, error) {
+func (i *IngressAPI[R]) Get(name, namespace string) (*R, error) {
 	res, err := i.Client.NetworkingV1().
 		Ingresses(namespace).
 		Get(i.Context, name, metav1.GetOptions{})
-	return res, err
+	if err != nil {
+		return nil, err
+	}
+
+	result, err := base.Cast[*R](res)
+	return result, err
 }
 
-func (i *IngressAPI) Create(namespace string, obj interface{}) error {
-	res := obj.(*net.Ingress)
-	_, err := i.Client.NetworkingV1().
+func (i *IngressAPI[R]) Create(namespace string, obj *R) error {
+	res, err := base.Cast[*net.Ingress](obj)
+	if err != nil {
+		return err
+	}
+
+	_, err = i.Client.NetworkingV1().
 		Ingresses(namespace).
 		Create(i.Context, res, metav1.CreateOptions{})
 	return err
 }
 
-func (i *IngressAPI) Update(namespace string, obj interface{}) error {
-	res := obj.(*net.Ingress)
-	_, err := i.Client.NetworkingV1().
+func (i *IngressAPI[R]) Update(namespace string, obj *R) error {
+	res, err := base.Cast[*net.Ingress](obj)
+	if err != nil {
+		return err
+	}
+
+	_, err = i.Client.NetworkingV1().
 		Ingresses(namespace).
 		Update(i.Context, res, metav1.UpdateOptions{})
 	return err
 }
 
-func (i *IngressAPI) List(namespace string) ([]interface{}, error) {
-	var res []interface{}
+func (i *IngressAPI[R]) List(namespace string) ([]R, error) {
+	res := []R{}
 	list, err := i.Client.NetworkingV1().
 		Ingresses(namespace).
 		List(i.Context, i.Opts.List)
+	if err != nil {
+		return nil, err
+	}
+
 	for _, v := range list.Items {
-		res = append(res, v)
+		item, err := base.Cast[R](v)
+		if err == nil {
+			res = append(res, item)
+		}
 	}
 	return res, err
 }
 
-func (i *IngressAPI) Delete(name, namespace string) error {
+func (i *IngressAPI[R]) Delete(name, namespace string) error {
 	return i.Client.NetworkingV1().
 		Ingresses(namespace).
 		Delete(i.Context, name, metav1.DeleteOptions{})

--- a/pkg/namespaced/resources/job.go
+++ b/pkg/namespaced/resources/job.go
@@ -3,7 +3,6 @@ package resources
 import (
 	"github.com/ilexPar/simple-kube/pkg/base"
 
-	sm "github.com/ilexPar/struct-marshal/pkg"
 	batch "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -24,59 +23,65 @@ type JobBehaviour struct {
 	FinishedTTL   int32            `sm:"spec.ttlSecondsAfterFinished"`
 }
 
-func (j Job) API() NamespacedResourceAPI {
-	return &JobAPI{}
-}
-
-func (j Job) Dump(from interface{}) (interface{}, error) {
-	res := &batch.Job{}
-	err := sm.Marshal(from, res)
-	return res, err
-}
-
-func (j Job) Load(from, into interface{}) error {
-	return sm.Unmarshal(from, into)
-}
-
-type JobAPI struct {
+type JobAPI[R base.KubernetesResources] struct {
 	base.KubeAPI
 }
 
-func (j *JobAPI) Get(name, namespace string) (interface{}, error) {
+func (j *JobAPI[R]) Get(name, namespace string) (*R, error) {
 	res, err := j.Client.BatchV1().
 		Jobs(namespace).
 		Get(j.Context, name, metav1.GetOptions{})
-	return res, err
+	if err != nil {
+		return nil, err
+	}
+
+	result, err := base.Cast[*R](res)
+	return result, err
 }
 
-func (j *JobAPI) Create(namespace string, obj interface{}) error {
-	res := obj.(*batch.Job)
-	_, err := j.Client.BatchV1().
+func (j *JobAPI[R]) Create(namespace string, obj *R) error {
+	res, err := base.Cast[*batch.Job](obj)
+	if err != nil {
+		return err
+	}
+
+	_, err = j.Client.BatchV1().
 		Jobs(namespace).
 		Create(j.Context, res, metav1.CreateOptions{})
 	return err
 }
 
-func (j *JobAPI) Update(namespace string, obj interface{}) error {
-	res := obj.(*batch.Job)
-	_, err := j.Client.BatchV1().
+func (j *JobAPI[R]) Update(namespace string, obj *R) error {
+	res, err := base.Cast[*batch.Job](obj)
+	if err != nil {
+		return err
+	}
+
+	_, err = j.Client.BatchV1().
 		Jobs(namespace).
 		Update(j.Context, res, metav1.UpdateOptions{})
 	return err
 }
 
-func (j *JobAPI) List(namespace string) ([]interface{}, error) {
-	var res []interface{}
+func (j *JobAPI[R]) List(namespace string) ([]R, error) {
+	res := []R{}
 	list, err := j.Client.BatchV1().
 		Jobs(namespace).
 		List(j.Context, j.Opts.List)
+	if err != nil {
+		return nil, err
+	}
+
 	for _, v := range list.Items {
-		res = append(res, v)
+		item, err := base.Cast[R](v)
+		if err == nil {
+			res = append(res, item)
+		}
 	}
 	return res, err
 }
 
-func (j *JobAPI) Delete(name, namespace string) error {
+func (j *JobAPI[R]) Delete(name, namespace string) error {
 	return j.Client.BatchV1().
 		Jobs(namespace).
 		Delete(j.Context, name, metav1.DeleteOptions{})

--- a/pkg/namespaced/resources/service.go
+++ b/pkg/namespaced/resources/service.go
@@ -3,7 +3,6 @@ package resources
 import (
 	"github.com/ilexPar/simple-kube/pkg/base"
 
-	sm "github.com/ilexPar/struct-marshal/pkg"
 	api "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -15,59 +14,66 @@ type Service struct {
 	Labels   map[string]string `sm:"metadata.labels"`
 }
 
-func (s Service) API() NamespacedResourceAPI {
-	return &ServiceAPI{}
-}
-
-func (s Service) Dump(from interface{}) (interface{}, error) {
-	res := &api.Service{}
-	err := sm.Marshal(from, res)
-	return res, err
-}
-
-func (s Service) Load(from, into interface{}) error {
-	return sm.Unmarshal(from, into)
-}
-
-type ServiceAPI struct {
+type ServiceAPI[R base.KubernetesResources] struct {
 	base.KubeAPI
 }
 
-func (s *ServiceAPI) Get(name, namespace string) (interface{}, error) {
+func (s *ServiceAPI[R]) Get(name, namespace string) (*R, error) {
 	res, err := s.Client.CoreV1().
 		Services(namespace).
 		Get(s.Context, name, metav1.GetOptions{})
-	return res, err
+	if err != nil {
+		return nil, err
+	}
+
+	result, err := base.Cast[*R](res)
+	return result, err
 }
 
-func (s *ServiceAPI) Create(namespace string, obj interface{}) error {
-	res := obj.(*api.Service)
-	_, err := s.Client.CoreV1().
+func (s *ServiceAPI[R]) Create(namespace string, obj *R) error {
+	res, err := base.Cast[*api.Service](obj)
+	if err != nil {
+		return err
+	}
+
+	_, err = s.Client.CoreV1().
 		Services(namespace).
 		Create(s.Context, res, metav1.CreateOptions{})
 	return err
 }
 
-func (s *ServiceAPI) Update(namespace string, obj interface{}) error {
-	res := obj.(*api.Service)
-	_, err := s.Client.CoreV1().
+func (s *ServiceAPI[R]) Update(namespace string, obj *R) error {
+	res, err := base.Cast[*api.Service](obj)
+	if err != nil {
+		return err
+	}
+
+	_, err = s.Client.CoreV1().
 		Services(namespace).
 		Update(s.Context, res, metav1.UpdateOptions{})
 	return err
 }
 
-func (s *ServiceAPI) List(namespace string) ([]interface{}, error) {
-	var res []interface{}
+func (s *ServiceAPI[R]) List(namespace string) ([]R, error) {
+	res := []R{}
 	list, err := s.Client.CoreV1().
 		Services(namespace).
 		List(s.Context, s.Opts.List)
+	if err != nil {
+		return nil, err
+	}
+
 	for _, v := range list.Items {
-		res = append(res, v)
+		item, err := base.Cast[R](v)
+		if err == nil {
+
+			res = append(res, item)
+		}
 	}
 	return res, err
 }
 
-func (s *ServiceAPI) Delete(name, namespace string) error {
+func (s *ServiceAPI[R]) Delete(name, namespace string) error {
 	return s.Client.CoreV1().
 		Services(namespace).
 		Delete(s.Context, name, metav1.DeleteOptions{})

--- a/pkg/namespaced/resources/types.go
+++ b/pkg/namespaced/resources/types.go
@@ -8,14 +8,14 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-type NamespacedResourceAPI interface {
+type NamespacedResourceAPI[R base.KubernetesResources] interface {
 	Config(ctx context.Context, k8s kubernetes.Interface)
 	SetOpts(opts base.QueryOpts)
 
-	Get(name, namespace string) (interface{}, error)
-	Create(namespace string, obj interface{}) error
-	Update(namespace string, obj interface{}) error
-	List(namespace string) ([]interface{}, error)
+	Get(name, namespace string) (*R, error)
+	Create(namespace string, obj *R) error
+	Update(namespace string, obj *R) error
+	List(namespace string) ([]R, error)
 	Delete(name, namespace string) error
 }
 

--- a/pkg/namespaced/types.go
+++ b/pkg/namespaced/types.go
@@ -3,54 +3,51 @@ package namespaced
 import (
 	"github.com/ilexPar/simple-kube/pkg/base"
 	"github.com/ilexPar/simple-kube/pkg/namespaced/resources"
+
+	apps "k8s.io/api/apps/v1"
+	scaling "k8s.io/api/autoscaling/v2"
+	batch "k8s.io/api/batch/v1"
+	api "k8s.io/api/core/v1"
+	net "k8s.io/api/networking/v1"
 )
 
-type NamespacedResourceMethods interface {
-	base.ResourceInterface
-}
-
-type NamespacedResourcesConstrain interface {
+type NamespacedResources interface {
 	resources.Deployment | resources.Service | resources.Job | resources.CronJob | resources.ConfigMap | resources.Ingress | resources.HPA
 }
 
-type NamespacedResources interface {
-	NamespacedResourcesConstrain
-	NamespacedResourceMethods
-}
-
 type QueryNamespace interface {
-	Deployment() NamespacedAction[resources.Deployment]
-	Service() NamespacedAction[resources.Service]
-	Job() NamespacedAction[resources.Job]
-	CronJob() NamespacedAction[resources.CronJob]
-	ConfigMap() NamespacedAction[resources.ConfigMap]
-	Ingress() NamespacedAction[resources.Ingress]
-	HPA() NamespacedAction[resources.HPA]
+	Deployment() NamespacedAction[resources.Deployment, apps.Deployment]
+	Service() NamespacedAction[resources.Service, api.Service]
+	Job() NamespacedAction[resources.Job, batch.Job]
+	CronJob() NamespacedAction[resources.CronJob, batch.CronJob]
+	ConfigMap() NamespacedAction[resources.ConfigMap, api.ConfigMap]
+	Ingress() NamespacedAction[resources.Ingress, net.Ingress]
+	HPA() NamespacedAction[resources.HPA, scaling.HorizontalPodAutoscaler]
 }
 
-type NamespacedAction[T NamespacedResources] interface {
-	Get(string) NamespacedGetInterface[T]
-	List() NamespacedListInterface[T]
-	Create(T) NamespacedPutInterface[T]
-	Update(T) NamespacedPutInterface[T]
-	Delete(string) NamespacedDeleteInterface[T]
+type NamespacedAction[T NamespacedResources, R base.KubernetesResources] interface {
+	Get(string) NamespacedGetInterface[T, R]
+	List() NamespacedListInterface[T, R]
+	Create(T) NamespacedPutInterface[T, R]
+	Update(T) NamespacedPutInterface[T, R]
+	Delete(string) NamespacedDeleteInterface[T, R]
 }
 
-type NamespacedGetInterface[T NamespacedResources] interface {
+type NamespacedGetInterface[T NamespacedResources, R base.KubernetesResources] interface {
 	Run() (T, error)
-	DataHandler(func(interface{}) error) NamespacedGetInterface[T]
+	DataHandler(func(*R) error) NamespacedGetInterface[T, R]
 }
 
-type NamespacedPutInterface[T NamespacedResources] interface {
+type NamespacedPutInterface[T NamespacedResources, R base.KubernetesResources] interface {
 	Run() error
-	DataHandler(func(interface{}) error) NamespacedPutInterface[T]
+	DataHandler(func(*R) error) NamespacedPutInterface[T, R]
 }
 
-type NamespacedListInterface[T NamespacedResources] interface {
+type NamespacedListInterface[T NamespacedResources, R base.KubernetesResources] interface {
 	Run() ([]T, error)
-	FilterByLabels(labels map[string]string) NamespacedListInterface[T]
+	FilterByLabels(labels map[string]string) NamespacedListInterface[T, R]
 }
 
-type NamespacedDeleteInterface[T NamespacedResources] interface {
+type NamespacedDeleteInterface[T NamespacedResources, R base.KubernetesResources] interface {
 	Run() error
 }

--- a/pkg/namespaced/types.go
+++ b/pkg/namespaced/types.go
@@ -7,8 +7,6 @@ import (
 
 type NamespacedResourceMethods interface {
 	base.ResourceInterface
-
-	API() resources.NamespacedResourceAPI
 }
 
 type NamespacedResourcesConstrain interface {

--- a/pkg/namespaced/update.go
+++ b/pkg/namespaced/update.go
@@ -1,13 +1,19 @@
 package namespaced
 
-type NamespacedUpdate[T NamespacedResources] struct {
-	Action[T]
+import (
+	"github.com/ilexPar/simple-kube/pkg/base"
+	sm "github.com/ilexPar/struct-marshal/pkg"
+)
+
+type NamespacedUpdate[T NamespacedResources, R base.KubernetesResources] struct {
+	Action[T, R]
 	Resource T
-	callback func(interface{}) error
+	callback func(*R) error
 }
 
-func (u *NamespacedUpdate[T]) Run() error {
-	obj, err := u.Resource.Dump(u.Resource)
+func (u *NamespacedUpdate[T, R]) Run() error {
+	obj := new(R)
+	err := sm.Marshal(u.Resource, obj)
 	if err != nil {
 		return err
 	}
@@ -22,9 +28,9 @@ func (u *NamespacedUpdate[T]) Run() error {
 	return err
 }
 
-func (u *NamespacedUpdate[T]) DataHandler(
-	handler func(interface{}) error,
-) NamespacedPutInterface[T] {
+func (u *NamespacedUpdate[T, R]) DataHandler(
+	handler func(*R) error,
+) NamespacedPutInterface[T, R] {
 	u.callback = handler
 	return u
 }

--- a/tests/cluster/namespace_test.go
+++ b/tests/cluster/namespace_test.go
@@ -18,15 +18,16 @@ import (
 )
 
 func TestNamespaceCreate(t *testing.T) {
+	client := sk.Client{}
 	new := skres.Namespace{
 		Name: "some-ns",
 	}
 
 	t.Run("should success without errors", func(t *testing.T) {
 		kt.WithInformedClient[skres.Namespace](t, kt.Create, func(k8s *fake.Clientset) {
-			client := sk.NewClient(context.Background(), k8s)
+			client.Config(context.Background(), k8s)
 
-			query := client.ClusterQuery().
+			query := client.
 				Namespace().
 				Create(new)
 			err := query.Run()
@@ -38,9 +39,9 @@ func TestNamespaceCreate(t *testing.T) {
 		kt.WithInformedClient[skres.Namespace](t, kt.Create, func(k8s *fake.Clientset) {
 			hasCallbackRun := false
 			baseKubeActions := 2
-			client := sk.NewClient(context.Background(), k8s)
+			client.Config(context.Background(), k8s)
 
-			query := client.ClusterQuery().
+			query := client.
 				Namespace().
 				Create(new).
 				DataHandler(func(res interface{}) error {
@@ -59,9 +60,9 @@ func TestNamespaceCreate(t *testing.T) {
 	})
 	t.Run("should cancel execution on callback error", func(t *testing.T) {
 		k8s := fake.NewSimpleClientset()
-		client := sk.NewClient(context.Background(), k8s)
+		client.Config(context.Background(), k8s)
 
-		query := client.ClusterQuery().
+		query := client.
 			Namespace().
 			Create(new).
 			DataHandler(func(res interface{}) error {
@@ -75,6 +76,7 @@ func TestNamespaceCreate(t *testing.T) {
 }
 
 func TestNamespaceUpdate(t *testing.T) {
+	client := sk.Client{}
 	old := &api.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "some-ns",
@@ -91,12 +93,9 @@ func TestNamespaceUpdate(t *testing.T) {
 	}
 	t.Run("should success without errors", func(t *testing.T) {
 		kt.WithInformedClient[skres.Namespace](t, kt.Update, func(k8s *fake.Clientset) {
-			client := sk.NewClient(context.Background(), k8s)
+			client.Config(context.Background(), k8s)
 
-			query := client.ClusterQuery().
-				Namespace().
-				Update(new)
-
+			query := client.Namespace().Update(new)
 			err := query.Run()
 
 			assert.Nil(t, err)
@@ -106,9 +105,9 @@ func TestNamespaceUpdate(t *testing.T) {
 		kt.WithInformedClient[skres.Namespace](t, kt.Update, func(k8s *fake.Clientset) {
 			hasCallbackRun := false
 			baseKubeActions := 2 // kube fake clients with informers starts with 2 actions
-			client := sk.NewClient(context.Background(), k8s)
+			client.Config(context.Background(), k8s)
 
-			query := client.ClusterQuery().
+			query := client.
 				Namespace().
 				Update(new).
 				DataHandler(func(res interface{}) error {
@@ -127,9 +126,9 @@ func TestNamespaceUpdate(t *testing.T) {
 	})
 	t.Run("should cancel execution on callback error", func(t *testing.T) {
 		k8s := fake.NewSimpleClientset(old)
-		client := sk.NewClient(context.Background(), k8s)
+		client.Config(context.Background(), k8s)
 
-		query := client.ClusterQuery().
+		query := client.
 			Namespace().
 			Update(new).
 			DataHandler(func(res interface{}) error {
@@ -143,6 +142,7 @@ func TestNamespaceUpdate(t *testing.T) {
 }
 
 func TestNamespaceGet(t *testing.T) {
+	client := sk.Client{}
 	kubeSvc := &api.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "my-ns",
@@ -151,20 +151,16 @@ func TestNamespaceGet(t *testing.T) {
 	expected := skres.Namespace{
 		Name: "my-ns",
 	}
-	client := sk.NewClient(context.Background(), fake.NewSimpleClientset(kubeSvc))
+	client.Config(context.Background(), fake.NewSimpleClientset(kubeSvc))
 
 	t.Run("should return custom error when not found", func(t *testing.T) {
-		query := client.ClusterQuery().
-			Namespace().
-			Get("not-found")
+		query := client.Namespace().Get("not-found")
 		_, err := query.Run()
 
 		assert.Equal(t, skerr.ERROR_NOT_FOUND, err.Error())
 	})
 	t.Run("should return expected object", func(t *testing.T) {
-		query := client.ClusterQuery().
-			Namespace().
-			Get("my-ns")
+		query := client.Namespace().Get("my-ns")
 		result, err := query.Run()
 
 		assert.Nil(t, err)
@@ -174,7 +170,7 @@ func TestNamespaceGet(t *testing.T) {
 		overrideLabels := map[string]string{
 			"test": "test",
 		}
-		query := client.ClusterQuery().
+		query := client.
 			Namespace().
 			Get("my-ns").
 			DataHandler(func(res interface{}) error {
@@ -188,7 +184,7 @@ func TestNamespaceGet(t *testing.T) {
 		assert.Equal(t, overrideLabels, result.Labels)
 	})
 	t.Run("should cancel execution on callback error", func(t *testing.T) {
-		query := client.ClusterQuery().
+		query := client.
 			Namespace().
 			Get("my-ns").
 			DataHandler(func(interface{}) error {
@@ -201,6 +197,7 @@ func TestNamespaceGet(t *testing.T) {
 }
 
 func TestNamespaceList(t *testing.T) {
+	client := sk.Client{}
 	ns1 := &api.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "my-ns",
@@ -219,19 +216,17 @@ func TestNamespaceList(t *testing.T) {
 		},
 	}
 
-	client := sk.NewClient(context.Background(), fake.NewSimpleClientset(ns1, ns2))
+	client.Config(context.Background(), fake.NewSimpleClientset(ns1, ns2))
 
 	t.Run("should return expected objects", func(t *testing.T) {
-		query := client.ClusterQuery().
-			Namespace().
-			List()
+		query := client.Namespace().List()
 		result, err := query.Run()
 
 		assert.Nil(t, err)
 		assert.Equal(t, 2, len(result))
 	})
 	t.Run("should filter by label", func(t *testing.T) {
-		query := client.ClusterQuery().
+		query := client.
 			Namespace().
 			List().
 			FilterByLabels(map[string]string{
@@ -245,6 +240,7 @@ func TestNamespaceList(t *testing.T) {
 }
 
 func TestServiceDelete(t *testing.T) {
+	client := sk.Client{}
 	dpl := &api.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "my-ns",
@@ -256,12 +252,9 @@ func TestServiceDelete(t *testing.T) {
 	}
 	t.Run("should return no errors when calling delete on an object", func(t *testing.T) {
 		k8s := fake.NewSimpleClientset(dpl)
-		client := sk.NewClient(context.Background(), k8s)
+		client.Config(context.Background(), k8s)
 
-		query := client.ClusterQuery().
-			Namespace().
-			Delete("my-ns")
-
+		query := client.Namespace().Delete("my-ns")
 		err := query.Run()
 
 		assert.Nil(t, err)

--- a/tests/k8sutil/main.go
+++ b/tests/k8sutil/main.go
@@ -30,7 +30,7 @@ const (
 )
 
 type k8sResources interface {
-	skns.NamespacedResourcesConstrain | skcl.ClusterResourcesConstrain
+	skns.NamespacedResources | skcl.ClusterResourcesConstrain
 }
 
 func WithInformedClient[T k8sResources](

--- a/tests/namespaced/configmap_test.go
+++ b/tests/namespaced/configmap_test.go
@@ -45,9 +45,8 @@ func TestConfigMapCreate(t *testing.T) {
 			query := client.NamespacedQuery("default").
 				ConfigMap().
 				Create(new).
-				DataHandler(func(res interface{}) error {
-					obj := res.(*api.ConfigMap)
-					assert.Equal(t, new.Name, obj.Name)
+				DataHandler(func(res *api.ConfigMap) error {
+					assert.Equal(t, new.Name, res.Name)
 					assert.Equal(t, baseKubeActions, len(k8s.Actions()))
 					hasCallbackRun = true
 					return nil
@@ -66,7 +65,7 @@ func TestConfigMapCreate(t *testing.T) {
 		query := client.NamespacedQuery("default").
 			ConfigMap().
 			Create(new).
-			DataHandler(func(res interface{}) error {
+			DataHandler(func(res *api.ConfigMap) error {
 				return errors.New("test error")
 			})
 		err := query.Run()
@@ -115,9 +114,8 @@ func TestConfigMapUpdate(t *testing.T) {
 			query := client.NamespacedQuery("default").
 				ConfigMap().
 				Update(new).
-				DataHandler(func(res interface{}) error {
-					obj := res.(*api.ConfigMap)
-					assert.Equal(t, new.Name, obj.Name)
+				DataHandler(func(res *api.ConfigMap) error {
+					assert.Equal(t, new.Name, res.Name)
 					assert.Equal(t, baseKubeActions, len(k8s.Actions()))
 					hasCallbackRun = true
 					return nil
@@ -136,7 +134,7 @@ func TestConfigMapUpdate(t *testing.T) {
 		query := client.NamespacedQuery("default").
 			ConfigMap().
 			Update(new).
-			DataHandler(func(res interface{}) error {
+			DataHandler(func(res *api.ConfigMap) error {
 				return errors.New("test error")
 			})
 		err := query.Run()
@@ -185,9 +183,8 @@ func TestConfigMapGet(t *testing.T) {
 		query := client.NamespacedQuery("default").
 			ConfigMap().
 			Get("my-config").
-			DataHandler(func(res interface{}) error {
-				cmap := res.(*api.ConfigMap)
-				cmap.Data["key"] = "override" // override
+			DataHandler(func(res *api.ConfigMap) error {
+				res.Data["key"] = "override" // override
 				return nil
 			})
 		result, err := query.Run()
@@ -199,7 +196,7 @@ func TestConfigMapGet(t *testing.T) {
 		query := client.NamespacedQuery("default").
 			ConfigMap().
 			Get("my-config").
-			DataHandler(func(interface{}) error {
+			DataHandler(func(res *api.ConfigMap) error {
 				return errors.New("test error")
 			})
 		_, err := query.Run()

--- a/tests/namespaced/configmap_test.go
+++ b/tests/namespaced/configmap_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 func TestConfigMapCreate(t *testing.T) {
+	client := sk.Client{}
 	new := skres.ConfigMap{
 		Name: "my-config",
 		Data: map[string]string{
@@ -26,9 +27,9 @@ func TestConfigMapCreate(t *testing.T) {
 
 	t.Run("should success without errors", func(t *testing.T) {
 		kt.WithInformedClient[skres.ConfigMap](t, kt.Create, func(k8s *fake.Clientset) {
-			client := sk.NewClient(context.Background(), k8s)
+			client.Config(context.Background(), k8s)
 
-			query := client.NamespacedQuery("default").
+			query := client.InNamespace("default").
 				ConfigMap().
 				Create(new)
 			err := query.Run()
@@ -40,9 +41,9 @@ func TestConfigMapCreate(t *testing.T) {
 		kt.WithInformedClient[skres.ConfigMap](t, kt.Create, func(k8s *fake.Clientset) {
 			hasCallbackRun := false
 			baseKubeActions := 2
-			client := sk.NewClient(context.Background(), k8s)
+			client.Config(context.Background(), k8s)
 
-			query := client.NamespacedQuery("default").
+			query := client.InNamespace("default").
 				ConfigMap().
 				Create(new).
 				DataHandler(func(res *api.ConfigMap) error {
@@ -60,9 +61,9 @@ func TestConfigMapCreate(t *testing.T) {
 	})
 	t.Run("should cancel execution on callback error", func(t *testing.T) {
 		k8s := fake.NewSimpleClientset()
-		client := sk.NewClient(context.Background(), k8s)
+		client.Config(context.Background(), k8s)
 
-		query := client.NamespacedQuery("default").
+		query := client.InNamespace("default").
 			ConfigMap().
 			Create(new).
 			DataHandler(func(res *api.ConfigMap) error {
@@ -77,6 +78,7 @@ func TestConfigMapCreate(t *testing.T) {
 }
 
 func TestConfigMapUpdate(t *testing.T) {
+	client := sk.Client{}
 	old := &api.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-config",
@@ -94,9 +96,9 @@ func TestConfigMapUpdate(t *testing.T) {
 	}
 	t.Run("should success without errors", func(t *testing.T) {
 		kt.WithInformedClient[skres.ConfigMap](t, kt.Update, func(k8s *fake.Clientset) {
-			client := sk.NewClient(context.Background(), k8s)
+			client.Config(context.Background(), k8s)
 
-			query := client.NamespacedQuery("default").
+			query := client.InNamespace("default").
 				ConfigMap().
 				Update(new)
 
@@ -109,9 +111,9 @@ func TestConfigMapUpdate(t *testing.T) {
 		kt.WithInformedClient[skres.ConfigMap](t, kt.Update, func(k8s *fake.Clientset) {
 			hasCallbackRun := false
 			baseKubeActions := 2 // kube fake clients with informers starts with 2 actions
-			client := sk.NewClient(context.Background(), k8s)
+			client.Config(context.Background(), k8s)
 
-			query := client.NamespacedQuery("default").
+			query := client.InNamespace("default").
 				ConfigMap().
 				Update(new).
 				DataHandler(func(res *api.ConfigMap) error {
@@ -129,9 +131,9 @@ func TestConfigMapUpdate(t *testing.T) {
 	})
 	t.Run("should cancel execution on callback error", func(t *testing.T) {
 		k8s := fake.NewSimpleClientset(old)
-		client := sk.NewClient(context.Background(), k8s)
+		client.Config(context.Background(), k8s)
 
-		query := client.NamespacedQuery("default").
+		query := client.InNamespace("default").
 			ConfigMap().
 			Update(new).
 			DataHandler(func(res *api.ConfigMap) error {
@@ -145,6 +147,7 @@ func TestConfigMapUpdate(t *testing.T) {
 }
 
 func TestConfigMapGet(t *testing.T) {
+	client := sk.Client{}
 	kubeSvc := &api.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-config",
@@ -160,10 +163,10 @@ func TestConfigMapGet(t *testing.T) {
 			"key": "value",
 		},
 	}
-	client := sk.NewClient(context.Background(), fake.NewSimpleClientset(kubeSvc))
+	client.Config(context.Background(), fake.NewSimpleClientset(kubeSvc))
 
 	t.Run("should return custom error when not found", func(t *testing.T) {
-		query := client.NamespacedQuery("default").
+		query := client.InNamespace("default").
 			ConfigMap().
 			Get("not-found")
 		_, err := query.Run()
@@ -171,7 +174,7 @@ func TestConfigMapGet(t *testing.T) {
 		assert.Equal(t, skerr.ERROR_NOT_FOUND, err.Error())
 	})
 	t.Run("should return expected object", func(t *testing.T) {
-		query := client.NamespacedQuery("default").
+		query := client.InNamespace("default").
 			ConfigMap().
 			Get("my-config")
 		result, err := query.Run()
@@ -180,7 +183,7 @@ func TestConfigMapGet(t *testing.T) {
 		assert.Equal(t, expected, result)
 	})
 	t.Run("should run DataHandler callback", func(t *testing.T) {
-		query := client.NamespacedQuery("default").
+		query := client.InNamespace("default").
 			ConfigMap().
 			Get("my-config").
 			DataHandler(func(res *api.ConfigMap) error {
@@ -193,7 +196,7 @@ func TestConfigMapGet(t *testing.T) {
 		assert.Equal(t, "override", result.Data["key"])
 	})
 	t.Run("should cancel execution on callback error", func(t *testing.T) {
-		query := client.NamespacedQuery("default").
+		query := client.InNamespace("default").
 			ConfigMap().
 			Get("my-config").
 			DataHandler(func(res *api.ConfigMap) error {
@@ -206,6 +209,7 @@ func TestConfigMapGet(t *testing.T) {
 }
 
 func TestConfigMapList(t *testing.T) {
+	client := sk.Client{}
 	cmap1 := &api.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-config",
@@ -231,10 +235,10 @@ func TestConfigMapList(t *testing.T) {
 			"key2": "different value",
 		},
 	}
-	client := sk.NewClient(context.Background(), fake.NewSimpleClientset(cmap1, cmap2))
+	client.Config(context.Background(), fake.NewSimpleClientset(cmap1, cmap2))
 
 	t.Run("should return expected objects", func(t *testing.T) {
-		query := client.NamespacedQuery("default").
+		query := client.InNamespace("default").
 			ConfigMap().
 			List()
 		result, err := query.Run()
@@ -243,7 +247,7 @@ func TestConfigMapList(t *testing.T) {
 		assert.Equal(t, 2, len(result))
 	})
 	t.Run("should filter by label", func(t *testing.T) {
-		query := client.NamespacedQuery("default").
+		query := client.InNamespace("default").
 			ConfigMap().
 			List().
 			FilterByLabels(map[string]string{
@@ -257,6 +261,7 @@ func TestConfigMapList(t *testing.T) {
 }
 
 func TestConfigMapDelete(t *testing.T) {
+	client := sk.Client{}
 	dpl := &api.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-config",
@@ -272,9 +277,9 @@ func TestConfigMapDelete(t *testing.T) {
 	}
 	t.Run("should return no errors when calling delete on an object", func(t *testing.T) {
 		k8s := fake.NewSimpleClientset(dpl)
-		client := sk.NewClient(context.Background(), k8s)
+		client.Config(context.Background(), k8s)
 
-		query := client.NamespacedQuery("default").
+		query := client.InNamespace("default").
 			ConfigMap().
 			Delete("my-config")
 

--- a/tests/namespaced/cronjob_test.go
+++ b/tests/namespaced/cronjob_test.go
@@ -49,9 +49,8 @@ func TestCronJobCreate(t *testing.T) {
 			query := client.NamespacedQuery("default").
 				CronJob().
 				Create(new).
-				DataHandler(func(res interface{}) error {
-					obj := res.(*batch.CronJob)
-					assert.Equal(t, new.Name, obj.Name)
+				DataHandler(func(res *batch.CronJob) error {
+					assert.Equal(t, new.Name, res.Name)
 					assert.Equal(t, baseKubeActions, len(k8s.Actions()))
 					hasCallbackRun = true
 					return nil
@@ -70,7 +69,7 @@ func TestCronJobCreate(t *testing.T) {
 		query := client.NamespacedQuery("default").
 			CronJob().
 			Create(new).
-			DataHandler(func(res interface{}) error {
+			DataHandler(func(res *batch.CronJob) error {
 				return errors.New("test error")
 			})
 		err := query.Run()
@@ -137,9 +136,8 @@ func TestCronJobUpdate(t *testing.T) {
 			query := client.NamespacedQuery("default").
 				CronJob().
 				Update(new).
-				DataHandler(func(res interface{}) error {
-					obj := res.(*batch.CronJob)
-					assert.Equal(t, new.Name, obj.Name)
+				DataHandler(func(res *batch.CronJob) error {
+					assert.Equal(t, new.Name, res.Name)
 					assert.Equal(t, baseKubeActions, len(k8s.Actions()))
 					hasCallbackRun = true
 					return nil
@@ -158,7 +156,7 @@ func TestCronJobUpdate(t *testing.T) {
 		query := client.NamespacedQuery("default").
 			CronJob().
 			Update(new).
-			DataHandler(func(res interface{}) error {
+			DataHandler(func(res *batch.CronJob) error {
 				return errors.New("test error")
 			})
 		err := query.Run()
@@ -225,8 +223,7 @@ func TestCronJobGet(t *testing.T) {
 		query := client.NamespacedQuery("default").
 			CronJob().
 			Get("my-cron").
-			DataHandler(func(res interface{}) error {
-				cron := res.(*batch.CronJob)
+			DataHandler(func(cron *batch.CronJob) error {
 				cron.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Image = "overrided"
 				return nil
 			})
@@ -239,7 +236,7 @@ func TestCronJobGet(t *testing.T) {
 		query := client.NamespacedQuery("default").
 			CronJob().
 			Get("my-cron").
-			DataHandler(func(interface{}) error {
+			DataHandler(func(*batch.CronJob) error {
 				return errors.New("test error")
 			})
 		_, err := query.Run()

--- a/tests/namespaced/cronjob_test.go
+++ b/tests/namespaced/cronjob_test.go
@@ -18,6 +18,7 @@ import (
 )
 
 func TestCronJobCreate(t *testing.T) {
+	client := sk.Client{}
 	new := skres.CronJob{
 		Name: "my-cron",
 		Containers: []skres.Container{
@@ -30,9 +31,9 @@ func TestCronJobCreate(t *testing.T) {
 
 	t.Run("should success without errors", func(t *testing.T) {
 		kt.WithInformedClient[skres.CronJob](t, kt.Create, func(k8s *fake.Clientset) {
-			client := sk.NewClient(context.Background(), k8s)
+			client.Config(context.Background(), k8s)
 
-			query := client.NamespacedQuery("default").
+			query := client.InNamespace("default").
 				CronJob().
 				Create(new)
 			err := query.Run()
@@ -44,9 +45,9 @@ func TestCronJobCreate(t *testing.T) {
 		kt.WithInformedClient[skres.CronJob](t, kt.Create, func(k8s *fake.Clientset) {
 			hasCallbackRun := false
 			baseKubeActions := 2
-			client := sk.NewClient(context.Background(), k8s)
+			client.Config(context.Background(), k8s)
 
-			query := client.NamespacedQuery("default").
+			query := client.InNamespace("default").
 				CronJob().
 				Create(new).
 				DataHandler(func(res *batch.CronJob) error {
@@ -64,9 +65,9 @@ func TestCronJobCreate(t *testing.T) {
 	})
 	t.Run("should cancel execution on callback error", func(t *testing.T) {
 		k8s := fake.NewSimpleClientset()
-		client := sk.NewClient(context.Background(), k8s)
+		client.Config(context.Background(), k8s)
 
-		query := client.NamespacedQuery("default").
+		query := client.InNamespace("default").
 			CronJob().
 			Create(new).
 			DataHandler(func(res *batch.CronJob) error {
@@ -81,6 +82,7 @@ func TestCronJobCreate(t *testing.T) {
 }
 
 func TestCronJobUpdate(t *testing.T) {
+	client := sk.Client{}
 	old := &batch.CronJob{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-cron",
@@ -116,9 +118,9 @@ func TestCronJobUpdate(t *testing.T) {
 	}
 	t.Run("should success without errors", func(t *testing.T) {
 		kt.WithInformedClient[skres.CronJob](t, kt.Update, func(k8s *fake.Clientset) {
-			client := sk.NewClient(context.Background(), k8s)
+			client.Config(context.Background(), k8s)
 
-			query := client.NamespacedQuery("default").
+			query := client.InNamespace("default").
 				CronJob().
 				Update(new)
 
@@ -131,9 +133,9 @@ func TestCronJobUpdate(t *testing.T) {
 		kt.WithInformedClient[skres.CronJob](t, kt.Update, func(k8s *fake.Clientset) {
 			hasCallbackRun := false
 			baseKubeActions := 2 // kube fake clients with informers starts with 2 actions
-			client := sk.NewClient(context.Background(), k8s)
+			client.Config(context.Background(), k8s)
 
-			query := client.NamespacedQuery("default").
+			query := client.InNamespace("default").
 				CronJob().
 				Update(new).
 				DataHandler(func(res *batch.CronJob) error {
@@ -151,9 +153,9 @@ func TestCronJobUpdate(t *testing.T) {
 	})
 	t.Run("should cancel execution on callback error", func(t *testing.T) {
 		k8s := fake.NewSimpleClientset(old)
-		client := sk.NewClient(context.Background(), k8s)
+		client.Config(context.Background(), k8s)
 
-		query := client.NamespacedQuery("default").
+		query := client.InNamespace("default").
 			CronJob().
 			Update(new).
 			DataHandler(func(res *batch.CronJob) error {
@@ -167,6 +169,7 @@ func TestCronJobUpdate(t *testing.T) {
 }
 
 func TestCronJobGet(t *testing.T) {
+	client := sk.Client{}
 	kubeCronJob := &batch.CronJob{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-cron",
@@ -200,10 +203,10 @@ func TestCronJobGet(t *testing.T) {
 			},
 		},
 	}
-	client := sk.NewClient(context.Background(), fake.NewSimpleClientset(kubeCronJob))
+	client.Config(context.Background(), fake.NewSimpleClientset(kubeCronJob))
 
 	t.Run("should return custom error when not found", func(t *testing.T) {
-		query := client.NamespacedQuery("default").
+		query := client.InNamespace("default").
 			CronJob().
 			Get("not-found")
 		_, err := query.Run()
@@ -211,7 +214,7 @@ func TestCronJobGet(t *testing.T) {
 		assert.Equal(t, skerr.ERROR_NOT_FOUND, err.Error())
 	})
 	t.Run("should return expected object", func(t *testing.T) {
-		query := client.NamespacedQuery("default").
+		query := client.InNamespace("default").
 			CronJob().
 			Get("my-cron")
 		result, err := query.Run()
@@ -220,7 +223,7 @@ func TestCronJobGet(t *testing.T) {
 		assert.Equal(t, expected, result)
 	})
 	t.Run("should run DataHandler callback", func(t *testing.T) {
-		query := client.NamespacedQuery("default").
+		query := client.InNamespace("default").
 			CronJob().
 			Get("my-cron").
 			DataHandler(func(cron *batch.CronJob) error {
@@ -233,7 +236,7 @@ func TestCronJobGet(t *testing.T) {
 		assert.Equal(t, "overrided", result.Containers[0].Image)
 	})
 	t.Run("should cancel execution on callback error", func(t *testing.T) {
-		query := client.NamespacedQuery("default").
+		query := client.InNamespace("default").
 			CronJob().
 			Get("my-cron").
 			DataHandler(func(*batch.CronJob) error {
@@ -246,6 +249,7 @@ func TestCronJobGet(t *testing.T) {
 }
 
 func TestCronJobList(t *testing.T) {
+	client := sk.Client{}
 	job1 := &batch.CronJob{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-cron",
@@ -300,13 +304,13 @@ func TestCronJobList(t *testing.T) {
 		},
 	}
 
-	client := sk.NewClient(
+	client.Config(
 		context.Background(),
 		fake.NewSimpleClientset(job1, job2),
 	)
 
 	t.Run("should return expected objects", func(t *testing.T) {
-		query := client.NamespacedQuery("default").
+		query := client.InNamespace("default").
 			CronJob().
 			List()
 		result, err := query.Run()
@@ -315,7 +319,7 @@ func TestCronJobList(t *testing.T) {
 		assert.Equal(t, 2, len(result))
 	})
 	t.Run("should filter by label", func(t *testing.T) {
-		query := client.NamespacedQuery("default").
+		query := client.InNamespace("default").
 			CronJob().
 			List().
 			FilterByLabels(map[string]string{
@@ -329,6 +333,7 @@ func TestCronJobList(t *testing.T) {
 }
 
 func TestCronJobDelete(t *testing.T) {
+	client := sk.Client{}
 	job := &batch.CronJob{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-cron",
@@ -358,9 +363,9 @@ func TestCronJobDelete(t *testing.T) {
 	}
 	t.Run("should return no errors when calling delete on an object", func(t *testing.T) {
 		k8s := fake.NewSimpleClientset(job)
-		client := sk.NewClient(context.Background(), k8s)
+		client.Config(context.Background(), k8s)
 
-		query := client.NamespacedQuery("default").
+		query := client.InNamespace("default").
 			CronJob().
 			Delete("my-cron")
 

--- a/tests/namespaced/deployment_test.go
+++ b/tests/namespaced/deployment_test.go
@@ -18,6 +18,7 @@ import (
 )
 
 func TestDeploymentCreate(t *testing.T) {
+	client := sk.Client{}
 	new := skres.Deployment{
 		Name: "my-deployment",
 		Containers: []skres.Container{
@@ -30,9 +31,9 @@ func TestDeploymentCreate(t *testing.T) {
 
 	t.Run("should success without errors", func(t *testing.T) {
 		kt.WithInformedClient[skres.Deployment](t, kt.Create, func(k8s *fake.Clientset) {
-			client := sk.NewClient(context.Background(), k8s)
+			client.Config(context.Background(), k8s)
 
-			query := client.NamespacedQuery("default").
+			query := client.InNamespace("default").
 				Deployment().
 				Create(new)
 			err := query.Run()
@@ -44,9 +45,9 @@ func TestDeploymentCreate(t *testing.T) {
 		kt.WithInformedClient[skres.Deployment](t, kt.Create, func(k8s *fake.Clientset) {
 			hasCallbackRun := false
 			baseKubeActions := 2
-			client := sk.NewClient(context.Background(), k8s)
+			client.Config(context.Background(), k8s)
 
-			query := client.NamespacedQuery("default").
+			query := client.InNamespace("default").
 				Deployment().
 				Create(new).
 				DataHandler(func(deployment *apps.Deployment) error {
@@ -64,9 +65,9 @@ func TestDeploymentCreate(t *testing.T) {
 	})
 	t.Run("should cancel execution on callback error", func(t *testing.T) {
 		k8s := fake.NewSimpleClientset()
-		client := sk.NewClient(context.Background(), k8s)
+		client.Config(context.Background(), k8s)
 
-		query := client.NamespacedQuery("default").
+		query := client.InNamespace("default").
 			Deployment().
 			Create(new).
 			DataHandler(func(*apps.Deployment) error {
@@ -81,6 +82,7 @@ func TestDeploymentCreate(t *testing.T) {
 }
 
 func TestDeploymentUpdate(t *testing.T) {
+	client := sk.Client{}
 	old := &apps.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-deployment",
@@ -110,9 +112,9 @@ func TestDeploymentUpdate(t *testing.T) {
 	}
 	t.Run("should success without errors", func(t *testing.T) {
 		kt.WithInformedClient[skres.Deployment](t, kt.Update, func(k8s *fake.Clientset) {
-			client := sk.NewClient(context.Background(), k8s)
+			client.Config(context.Background(), k8s)
 
-			query := client.NamespacedQuery("default").
+			query := client.InNamespace("default").
 				Deployment().
 				Update(new)
 
@@ -125,9 +127,9 @@ func TestDeploymentUpdate(t *testing.T) {
 		kt.WithInformedClient[skres.Deployment](t, kt.Update, func(k8s *fake.Clientset) {
 			hasCallbackRun := false
 			baseKubeActions := 2 // kube fake clients with informers starts with 2 actions
-			client := sk.NewClient(context.Background(), k8s)
+			client.Config(context.Background(), k8s)
 
-			query := client.NamespacedQuery("default").
+			query := client.InNamespace("default").
 				Deployment().
 				Update(new).
 				DataHandler(func(deployment *apps.Deployment) error {
@@ -145,9 +147,9 @@ func TestDeploymentUpdate(t *testing.T) {
 	})
 	t.Run("should cancel execution on callback error", func(t *testing.T) {
 		k8s := fake.NewSimpleClientset(old)
-		client := sk.NewClient(context.Background(), k8s)
+		client.Config(context.Background(), k8s)
 
-		query := client.NamespacedQuery("default").
+		query := client.InNamespace("default").
 			Deployment().
 			Update(new).
 			DataHandler(func(*apps.Deployment) error {
@@ -161,6 +163,7 @@ func TestDeploymentUpdate(t *testing.T) {
 }
 
 func TestDeploymentGet(t *testing.T) {
+	client := sk.Client{}
 	kubeDeployment := &apps.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-deployment",
@@ -188,10 +191,10 @@ func TestDeploymentGet(t *testing.T) {
 			},
 		},
 	}
-	client := sk.NewClient(context.Background(), fake.NewSimpleClientset(kubeDeployment))
+	client.Config(context.Background(), fake.NewSimpleClientset(kubeDeployment))
 
 	t.Run("should return custom error when not found", func(t *testing.T) {
-		query := client.NamespacedQuery("default").
+		query := client.InNamespace("default").
 			Deployment().
 			Get("not-found")
 		_, err := query.Run()
@@ -199,7 +202,7 @@ func TestDeploymentGet(t *testing.T) {
 		assert.Equal(t, skerr.ERROR_NOT_FOUND, err.Error())
 	})
 	t.Run("should return expected object", func(t *testing.T) {
-		query := client.NamespacedQuery("default").
+		query := client.InNamespace("default").
 			Deployment().
 			Get("my-deployment")
 		result, err := query.Run()
@@ -208,7 +211,7 @@ func TestDeploymentGet(t *testing.T) {
 		assert.Equal(t, expected, result)
 	})
 	t.Run("should run DataHandler callback", func(t *testing.T) {
-		query := client.NamespacedQuery("default").
+		query := client.InNamespace("default").
 			Deployment().
 			Get("my-deployment").
 			DataHandler(func(deployment *apps.Deployment) error {
@@ -221,7 +224,7 @@ func TestDeploymentGet(t *testing.T) {
 		assert.Equal(t, "overrided", result.Containers[0].Image)
 	})
 	t.Run("should cancel execution on callback error", func(t *testing.T) {
-		query := client.NamespacedQuery("default").
+		query := client.InNamespace("default").
 			Deployment().
 			Get("my-deployment").
 			DataHandler(func(*apps.Deployment) error {
@@ -234,6 +237,7 @@ func TestDeploymentGet(t *testing.T) {
 }
 
 func TestDeploymentList(t *testing.T) {
+	client := sk.Client{}
 	dpl1 := &apps.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-deployment",
@@ -278,13 +282,13 @@ func TestDeploymentList(t *testing.T) {
 		},
 	}
 
-	client := sk.NewClient(
+	client.Config(
 		context.Background(),
 		fake.NewSimpleClientset(dpl1, dpl2),
 	)
 
 	t.Run("should return expected objects", func(t *testing.T) {
-		query := client.NamespacedQuery("default").
+		query := client.InNamespace("default").
 			Deployment().
 			List()
 		result, err := query.Run()
@@ -293,7 +297,7 @@ func TestDeploymentList(t *testing.T) {
 		assert.Equal(t, 2, len(result))
 	})
 	t.Run("should filter by label", func(t *testing.T) {
-		query := client.NamespacedQuery("default").
+		query := client.InNamespace("default").
 			Deployment().
 			List().
 			FilterByLabels(map[string]string{
@@ -307,6 +311,7 @@ func TestDeploymentList(t *testing.T) {
 }
 
 func TestDeploymentDelete(t *testing.T) {
+	client := sk.Client{}
 	dpl := &apps.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-deployment",
@@ -331,9 +336,9 @@ func TestDeploymentDelete(t *testing.T) {
 	}
 	t.Run("should return no errors when calling delete on an object", func(t *testing.T) {
 		k8s := fake.NewSimpleClientset(dpl)
-		client := sk.NewClient(context.Background(), k8s)
+		client.Config(context.Background(), k8s)
 
-		query := client.NamespacedQuery("default").
+		query := client.InNamespace("default").
 			Deployment().
 			Delete("my-deployment")
 

--- a/tests/namespaced/deployment_test.go
+++ b/tests/namespaced/deployment_test.go
@@ -49,9 +49,8 @@ func TestDeploymentCreate(t *testing.T) {
 			query := client.NamespacedQuery("default").
 				Deployment().
 				Create(new).
-				DataHandler(func(res interface{}) error {
-					obj := res.(*apps.Deployment)
-					assert.Equal(t, new.Name, obj.Name)
+				DataHandler(func(deployment *apps.Deployment) error {
+					assert.Equal(t, new.Name, deployment.Name)
 					assert.Equal(t, baseKubeActions, len(k8s.Actions()))
 					hasCallbackRun = true
 					return nil
@@ -70,7 +69,7 @@ func TestDeploymentCreate(t *testing.T) {
 		query := client.NamespacedQuery("default").
 			Deployment().
 			Create(new).
-			DataHandler(func(res interface{}) error {
+			DataHandler(func(*apps.Deployment) error {
 				return errors.New("test error")
 			})
 		err := query.Run()
@@ -131,9 +130,8 @@ func TestDeploymentUpdate(t *testing.T) {
 			query := client.NamespacedQuery("default").
 				Deployment().
 				Update(new).
-				DataHandler(func(res interface{}) error {
-					obj := res.(*apps.Deployment)
-					assert.Equal(t, new.Name, obj.Name)
+				DataHandler(func(deployment *apps.Deployment) error {
+					assert.Equal(t, new.Name, deployment.Name)
 					assert.Equal(t, baseKubeActions, len(k8s.Actions()))
 					hasCallbackRun = true
 					return nil
@@ -152,7 +150,7 @@ func TestDeploymentUpdate(t *testing.T) {
 		query := client.NamespacedQuery("default").
 			Deployment().
 			Update(new).
-			DataHandler(func(res interface{}) error {
+			DataHandler(func(*apps.Deployment) error {
 				return errors.New("test error")
 			})
 		err := query.Run()
@@ -213,8 +211,7 @@ func TestDeploymentGet(t *testing.T) {
 		query := client.NamespacedQuery("default").
 			Deployment().
 			Get("my-deployment").
-			DataHandler(func(res interface{}) error {
-				deployment := res.(*apps.Deployment)
+			DataHandler(func(deployment *apps.Deployment) error {
 				deployment.Spec.Template.Spec.Containers[0].Image = "overrided"
 				return nil
 			})
@@ -227,7 +224,7 @@ func TestDeploymentGet(t *testing.T) {
 		query := client.NamespacedQuery("default").
 			Deployment().
 			Get("my-deployment").
-			DataHandler(func(interface{}) error {
+			DataHandler(func(*apps.Deployment) error {
 				return errors.New("test error")
 			})
 		_, err := query.Run()

--- a/tests/namespaced/hpa_test.go
+++ b/tests/namespaced/hpa_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 func TestHPACreate(t *testing.T) {
+	client := sk.Client{}
 	new := skres.HPA{
 		Name: "my-deployment",
 		Min:  1,
@@ -24,9 +25,9 @@ func TestHPACreate(t *testing.T) {
 
 	t.Run("should success without errors", func(t *testing.T) {
 		kt.WithInformedClient[skres.HPA](t, kt.Create, func(k8s *fake.Clientset) {
-			client := sk.NewClient(context.Background(), k8s)
+			client.Config(context.Background(), k8s)
 
-			query := client.NamespacedQuery("default").
+			query := client.InNamespace("default").
 				HPA().
 				Create(new)
 			err := query.Run()
@@ -38,9 +39,9 @@ func TestHPACreate(t *testing.T) {
 		kt.WithInformedClient[skres.HPA](t, kt.Create, func(k8s *fake.Clientset) {
 			hasCallbackRun := false
 			baseKubeActions := 2
-			client := sk.NewClient(context.Background(), k8s)
+			client.Config(context.Background(), k8s)
 
-			query := client.NamespacedQuery("default").
+			query := client.InNamespace("default").
 				HPA().
 				Create(new).
 				DataHandler(func(hpa *scaling.HorizontalPodAutoscaler) error {
@@ -58,9 +59,9 @@ func TestHPACreate(t *testing.T) {
 	})
 	t.Run("should cancel execution on callback error", func(t *testing.T) {
 		k8s := fake.NewSimpleClientset()
-		client := sk.NewClient(context.Background(), k8s)
+		client.Config(context.Background(), k8s)
 
-		query := client.NamespacedQuery("default").
+		query := client.InNamespace("default").
 			HPA().
 			Create(new).
 			DataHandler(func(*scaling.HorizontalPodAutoscaler) error {
@@ -75,6 +76,7 @@ func TestHPACreate(t *testing.T) {
 }
 
 func TestHPAUpdate(t *testing.T) {
+	client := sk.Client{}
 	minReplicas := int32(1)
 	old := &scaling.HorizontalPodAutoscaler{
 		ObjectMeta: metav1.ObjectMeta{
@@ -93,9 +95,9 @@ func TestHPAUpdate(t *testing.T) {
 	}
 	t.Run("should success without errors", func(t *testing.T) {
 		kt.WithInformedClient[skres.HPA](t, kt.Update, func(k8s *fake.Clientset) {
-			client := sk.NewClient(context.Background(), k8s)
+			client.Config(context.Background(), k8s)
 
-			query := client.NamespacedQuery("default").
+			query := client.InNamespace("default").
 				HPA().
 				Update(new)
 
@@ -108,9 +110,9 @@ func TestHPAUpdate(t *testing.T) {
 		kt.WithInformedClient[skres.HPA](t, kt.Update, func(k8s *fake.Clientset) {
 			hasCallbackRun := false
 			baseKubeActions := 2 // kube fake clients with informers starts with 2 actions
-			client := sk.NewClient(context.Background(), k8s)
+			client.Config(context.Background(), k8s)
 
-			query := client.NamespacedQuery("default").
+			query := client.InNamespace("default").
 				HPA().
 				Update(new).
 				DataHandler(func(hpa *scaling.HorizontalPodAutoscaler) error {
@@ -128,9 +130,9 @@ func TestHPAUpdate(t *testing.T) {
 	})
 	t.Run("should cancel execution on callback error", func(t *testing.T) {
 		k8s := fake.NewSimpleClientset(old)
-		client := sk.NewClient(context.Background(), k8s)
+		client.Config(context.Background(), k8s)
 
-		query := client.NamespacedQuery("default").
+		query := client.InNamespace("default").
 			HPA().
 			Update(new).
 			DataHandler(func(*scaling.HorizontalPodAutoscaler) error {
@@ -144,6 +146,7 @@ func TestHPAUpdate(t *testing.T) {
 }
 
 func TestHPAGet(t *testing.T) {
+	client := sk.Client{}
 	minReplicas := int32(1)
 	utilization := int32(70)
 	kubeHPA := &scaling.HorizontalPodAutoscaler{
@@ -189,10 +192,10 @@ func TestHPAGet(t *testing.T) {
 			},
 		}},
 	}
-	client := sk.NewClient(context.Background(), fake.NewSimpleClientset(kubeHPA))
+	client.Config(context.Background(), fake.NewSimpleClientset(kubeHPA))
 
 	t.Run("should return custom error when not found", func(t *testing.T) {
-		query := client.NamespacedQuery("default").
+		query := client.InNamespace("default").
 			HPA().
 			Get("not-found")
 		_, err := query.Run()
@@ -200,7 +203,7 @@ func TestHPAGet(t *testing.T) {
 		assert.Equal(t, skerr.ERROR_NOT_FOUND, err.Error())
 	})
 	t.Run("should return expected object", func(t *testing.T) {
-		query := client.NamespacedQuery("default").
+		query := client.InNamespace("default").
 			HPA().
 			Get("my-deployment")
 		result, err := query.Run()
@@ -209,7 +212,7 @@ func TestHPAGet(t *testing.T) {
 		assert.Equal(t, expected, result)
 	})
 	t.Run("should run DataHandler callback", func(t *testing.T) {
-		query := client.NamespacedQuery("default").
+		query := client.InNamespace("default").
 			HPA().
 			Get("my-deployment").
 			DataHandler(func(hpa *scaling.HorizontalPodAutoscaler) error {
@@ -222,7 +225,7 @@ func TestHPAGet(t *testing.T) {
 		assert.Equal(t, 11, result.Max)
 	})
 	t.Run("should cancel execution on callback error", func(t *testing.T) {
-		query := client.NamespacedQuery("default").
+		query := client.InNamespace("default").
 			HPA().
 			Get("my-deployment").
 			DataHandler(func(*scaling.HorizontalPodAutoscaler) error {
@@ -235,6 +238,7 @@ func TestHPAGet(t *testing.T) {
 }
 
 func TestHPAList(t *testing.T) {
+	client := sk.Client{}
 	minReplicas := int32(1)
 	hpa1 := &scaling.HorizontalPodAutoscaler{
 		ObjectMeta: metav1.ObjectMeta{
@@ -264,13 +268,13 @@ func TestHPAList(t *testing.T) {
 		},
 	}
 
-	client := sk.NewClient(
+	client.Config(
 		context.Background(),
 		fake.NewSimpleClientset(hpa1, hpa2),
 	)
 
 	t.Run("should return expected objects", func(t *testing.T) {
-		query := client.NamespacedQuery("default").
+		query := client.InNamespace("default").
 			HPA().
 			List()
 		result, err := query.Run()
@@ -279,7 +283,7 @@ func TestHPAList(t *testing.T) {
 		assert.Equal(t, 2, len(result))
 	})
 	t.Run("should filter by label", func(t *testing.T) {
-		query := client.NamespacedQuery("default").
+		query := client.InNamespace("default").
 			HPA().
 			List().
 			FilterByLabels(map[string]string{
@@ -293,6 +297,7 @@ func TestHPAList(t *testing.T) {
 }
 
 func TestHPADelete(t *testing.T) {
+	client := sk.Client{}
 	hpa := &scaling.HorizontalPodAutoscaler{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-deployment",
@@ -308,9 +313,9 @@ func TestHPADelete(t *testing.T) {
 	}
 	t.Run("should return no errors when calling delete on an object", func(t *testing.T) {
 		k8s := fake.NewSimpleClientset(hpa)
-		client := sk.NewClient(context.Background(), k8s)
+		client.Config(context.Background(), k8s)
 
-		query := client.NamespacedQuery("default").
+		query := client.InNamespace("default").
 			HPA().
 			Delete("my-deployment")
 

--- a/tests/namespaced/hpa_test.go
+++ b/tests/namespaced/hpa_test.go
@@ -43,9 +43,8 @@ func TestHPACreate(t *testing.T) {
 			query := client.NamespacedQuery("default").
 				HPA().
 				Create(new).
-				DataHandler(func(res interface{}) error {
-					obj := res.(*scaling.HorizontalPodAutoscaler)
-					assert.Equal(t, new.Name, obj.Name)
+				DataHandler(func(hpa *scaling.HorizontalPodAutoscaler) error {
+					assert.Equal(t, new.Name, hpa.Name)
 					assert.Equal(t, baseKubeActions, len(k8s.Actions()))
 					hasCallbackRun = true
 					return nil
@@ -64,7 +63,7 @@ func TestHPACreate(t *testing.T) {
 		query := client.NamespacedQuery("default").
 			HPA().
 			Create(new).
-			DataHandler(func(res interface{}) error {
+			DataHandler(func(*scaling.HorizontalPodAutoscaler) error {
 				return errors.New("test error")
 			})
 		err := query.Run()
@@ -114,9 +113,8 @@ func TestHPAUpdate(t *testing.T) {
 			query := client.NamespacedQuery("default").
 				HPA().
 				Update(new).
-				DataHandler(func(res interface{}) error {
-					obj := res.(*scaling.HorizontalPodAutoscaler)
-					assert.Equal(t, new.Name, obj.Name)
+				DataHandler(func(hpa *scaling.HorizontalPodAutoscaler) error {
+					assert.Equal(t, new.Name, hpa.Name)
 					assert.Equal(t, baseKubeActions, len(k8s.Actions()))
 					hasCallbackRun = true
 					return nil
@@ -135,7 +133,7 @@ func TestHPAUpdate(t *testing.T) {
 		query := client.NamespacedQuery("default").
 			HPA().
 			Update(new).
-			DataHandler(func(res interface{}) error {
+			DataHandler(func(*scaling.HorizontalPodAutoscaler) error {
 				return errors.New("test error")
 			})
 		err := query.Run()
@@ -214,9 +212,8 @@ func TestHPAGet(t *testing.T) {
 		query := client.NamespacedQuery("default").
 			HPA().
 			Get("my-deployment").
-			DataHandler(func(res interface{}) error {
-				deployment := res.(*scaling.HorizontalPodAutoscaler)
-				deployment.Spec.MaxReplicas = 11
+			DataHandler(func(hpa *scaling.HorizontalPodAutoscaler) error {
+				hpa.Spec.MaxReplicas = 11
 				return nil
 			})
 		result, err := query.Run()
@@ -228,7 +225,7 @@ func TestHPAGet(t *testing.T) {
 		query := client.NamespacedQuery("default").
 			HPA().
 			Get("my-deployment").
-			DataHandler(func(interface{}) error {
+			DataHandler(func(*scaling.HorizontalPodAutoscaler) error {
 				return errors.New("test error")
 			})
 		_, err := query.Run()

--- a/tests/namespaced/ingress_test.go
+++ b/tests/namespaced/ingress_test.go
@@ -50,9 +50,8 @@ func TestIngressCreate(t *testing.T) {
 			query := client.NamespacedQuery("default").
 				Ingress().
 				Create(new).
-				DataHandler(func(res interface{}) error {
-					obj := res.(*net.Ingress)
-					assert.Equal(t, new.Name, obj.Name)
+				DataHandler(func(ingress *net.Ingress) error {
+					assert.Equal(t, new.Name, ingress.Name)
 					assert.Equal(t, baseKubeActions, len(k8s.Actions()))
 					hasCallbackRun = true
 					return nil
@@ -71,7 +70,7 @@ func TestIngressCreate(t *testing.T) {
 		query := client.NamespacedQuery("default").
 			Ingress().
 			Create(new).
-			DataHandler(func(res interface{}) error {
+			DataHandler(func(*net.Ingress) error {
 				return errors.New("test error")
 			})
 		err := query.Run()
@@ -146,9 +145,8 @@ func TestIngressUpdate(t *testing.T) {
 			query := client.NamespacedQuery("default").
 				Ingress().
 				Update(new).
-				DataHandler(func(res interface{}) error {
-					obj := res.(*net.Ingress)
-					assert.Equal(t, new.Name, obj.Name)
+				DataHandler(func(ingress *net.Ingress) error {
+					assert.Equal(t, new.Name, ingress.Name)
 					assert.Equal(t, baseKubeActions, len(k8s.Actions()))
 					hasCallbackRun = true
 					return nil
@@ -167,7 +165,7 @@ func TestIngressUpdate(t *testing.T) {
 		query := client.NamespacedQuery("default").
 			Ingress().
 			Update(new).
-			DataHandler(func(res interface{}) error {
+			DataHandler(func(*net.Ingress) error {
 				return errors.New("test error")
 			})
 		err := query.Run()
@@ -242,9 +240,8 @@ func TestIngressGet(t *testing.T) {
 		query := client.NamespacedQuery("default").
 			Ingress().
 			Get("my-ingress").
-			DataHandler(func(res interface{}) error {
-				svc := res.(*net.Ingress)
-				svc.Spec.Rules[0].Host = "overriden.com"
+			DataHandler(func(ingress *net.Ingress) error {
+				ingress.Spec.Rules[0].Host = "overriden.com"
 				return nil
 			})
 		result, err := query.Run()
@@ -256,7 +253,7 @@ func TestIngressGet(t *testing.T) {
 		query := client.NamespacedQuery("default").
 			Ingress().
 			Get("my-ingress").
-			DataHandler(func(interface{}) error {
+			DataHandler(func(*net.Ingress) error {
 				return errors.New("test error")
 			})
 		_, err := query.Run()

--- a/tests/namespaced/ingress_test.go
+++ b/tests/namespaced/ingress_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 func TestIngressCreate(t *testing.T) {
+	client := sk.Client{}
 	new := skres.Ingress{
 		Name:   "my-ingress",
 		Domain: "example.com",
@@ -31,9 +32,9 @@ func TestIngressCreate(t *testing.T) {
 
 	t.Run("should success without errors", func(t *testing.T) {
 		kt.WithInformedClient[skres.Ingress](t, kt.Create, func(k8s *fake.Clientset) {
-			client := sk.NewClient(context.Background(), k8s)
+			client.Config(context.Background(), k8s)
 
-			query := client.NamespacedQuery("default").
+			query := client.InNamespace("default").
 				Ingress().
 				Create(new)
 			err := query.Run()
@@ -45,9 +46,9 @@ func TestIngressCreate(t *testing.T) {
 		kt.WithInformedClient[skres.Ingress](t, kt.Create, func(k8s *fake.Clientset) {
 			hasCallbackRun := false
 			baseKubeActions := 2
-			client := sk.NewClient(context.Background(), k8s)
+			client.Config(context.Background(), k8s)
 
-			query := client.NamespacedQuery("default").
+			query := client.InNamespace("default").
 				Ingress().
 				Create(new).
 				DataHandler(func(ingress *net.Ingress) error {
@@ -65,9 +66,9 @@ func TestIngressCreate(t *testing.T) {
 	})
 	t.Run("should cancel execution on callback error", func(t *testing.T) {
 		k8s := fake.NewSimpleClientset()
-		client := sk.NewClient(context.Background(), k8s)
+		client.Config(context.Background(), k8s)
 
-		query := client.NamespacedQuery("default").
+		query := client.InNamespace("default").
 			Ingress().
 			Create(new).
 			DataHandler(func(*net.Ingress) error {
@@ -82,6 +83,7 @@ func TestIngressCreate(t *testing.T) {
 }
 
 func TestIngressUpdate(t *testing.T) {
+	client := sk.Client{}
 	old := &net.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-ingress",
@@ -125,9 +127,9 @@ func TestIngressUpdate(t *testing.T) {
 	}
 	t.Run("should success without errors", func(t *testing.T) {
 		kt.WithInformedClient[skres.Ingress](t, kt.Update, func(k8s *fake.Clientset) {
-			client := sk.NewClient(context.Background(), k8s)
+			client.Config(context.Background(), k8s)
 
-			query := client.NamespacedQuery("default").
+			query := client.InNamespace("default").
 				Ingress().
 				Update(new)
 
@@ -140,9 +142,9 @@ func TestIngressUpdate(t *testing.T) {
 		kt.WithInformedClient[skres.Ingress](t, kt.Update, func(k8s *fake.Clientset) {
 			hasCallbackRun := false
 			baseKubeActions := 2 // kube fake clients with informers starts with 2 actions
-			client := sk.NewClient(context.Background(), k8s)
+			client.Config(context.Background(), k8s)
 
-			query := client.NamespacedQuery("default").
+			query := client.InNamespace("default").
 				Ingress().
 				Update(new).
 				DataHandler(func(ingress *net.Ingress) error {
@@ -160,9 +162,9 @@ func TestIngressUpdate(t *testing.T) {
 	})
 	t.Run("should cancel execution on callback error", func(t *testing.T) {
 		k8s := fake.NewSimpleClientset(old)
-		client := sk.NewClient(context.Background(), k8s)
+		client.Config(context.Background(), k8s)
 
-		query := client.NamespacedQuery("default").
+		query := client.InNamespace("default").
 			Ingress().
 			Update(new).
 			DataHandler(func(*net.Ingress) error {
@@ -176,6 +178,7 @@ func TestIngressUpdate(t *testing.T) {
 }
 
 func TestIngressGet(t *testing.T) {
+	client := sk.Client{}
 	kubeSvc := &net.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-ingress",
@@ -217,10 +220,10 @@ func TestIngressGet(t *testing.T) {
 			},
 		},
 	}
-	client := sk.NewClient(context.Background(), fake.NewSimpleClientset(kubeSvc))
+	client.Config(context.Background(), fake.NewSimpleClientset(kubeSvc))
 
 	t.Run("should return custom error when not found", func(t *testing.T) {
-		query := client.NamespacedQuery("default").
+		query := client.InNamespace("default").
 			Ingress().
 			Get("not-found")
 		_, err := query.Run()
@@ -228,7 +231,7 @@ func TestIngressGet(t *testing.T) {
 		assert.Equal(t, skerr.ERROR_NOT_FOUND, err.Error())
 	})
 	t.Run("should return expected object", func(t *testing.T) {
-		query := client.NamespacedQuery("default").
+		query := client.InNamespace("default").
 			Ingress().
 			Get("my-ingress")
 		result, err := query.Run()
@@ -237,7 +240,7 @@ func TestIngressGet(t *testing.T) {
 		assert.Equal(t, expected, result)
 	})
 	t.Run("should run DataHandler callback", func(t *testing.T) {
-		query := client.NamespacedQuery("default").
+		query := client.InNamespace("default").
 			Ingress().
 			Get("my-ingress").
 			DataHandler(func(ingress *net.Ingress) error {
@@ -250,7 +253,7 @@ func TestIngressGet(t *testing.T) {
 		assert.Equal(t, "overriden.com", result.Domain)
 	})
 	t.Run("should cancel execution on callback error", func(t *testing.T) {
-		query := client.NamespacedQuery("default").
+		query := client.InNamespace("default").
 			Ingress().
 			Get("my-ingress").
 			DataHandler(func(*net.Ingress) error {
@@ -263,6 +266,7 @@ func TestIngressGet(t *testing.T) {
 }
 
 func TestIngressList(t *testing.T) {
+	client := sk.Client{}
 	igr1 := &net.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-ingress",
@@ -330,10 +334,10 @@ func TestIngressList(t *testing.T) {
 			},
 		},
 	}
-	client := sk.NewClient(context.Background(), fake.NewSimpleClientset(igr1, igr2))
+	client.Config(context.Background(), fake.NewSimpleClientset(igr1, igr2))
 
 	t.Run("should return expected objects", func(t *testing.T) {
-		query := client.NamespacedQuery("default").
+		query := client.InNamespace("default").
 			Ingress().
 			List()
 		result, err := query.Run()
@@ -342,7 +346,7 @@ func TestIngressList(t *testing.T) {
 		assert.Equal(t, 2, len(result))
 	})
 	t.Run("should filter by label", func(t *testing.T) {
-		query := client.NamespacedQuery("default").
+		query := client.InNamespace("default").
 			Ingress().
 			List().
 			FilterByLabels(map[string]string{
@@ -356,6 +360,7 @@ func TestIngressList(t *testing.T) {
 }
 
 func TestIngressDelete(t *testing.T) {
+	client := sk.Client{}
 	dpl := &net.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-ingress",
@@ -388,9 +393,9 @@ func TestIngressDelete(t *testing.T) {
 	}
 	t.Run("should return no errors when calling delete on an object", func(t *testing.T) {
 		k8s := fake.NewSimpleClientset(dpl)
-		client := sk.NewClient(context.Background(), k8s)
+		client.Config(context.Background(), k8s)
 
-		query := client.NamespacedQuery("default").
+		query := client.InNamespace("default").
 			Ingress().
 			Delete("my-ingress")
 

--- a/tests/namespaced/jobs_test.go
+++ b/tests/namespaced/jobs_test.go
@@ -18,6 +18,7 @@ import (
 )
 
 func TestJobCreate(t *testing.T) {
+	client := sk.Client{}
 	new := skres.Job{
 		Name: "my-job",
 		Containers: []skres.Container{
@@ -30,9 +31,9 @@ func TestJobCreate(t *testing.T) {
 
 	t.Run("should success without errors", func(t *testing.T) {
 		kt.WithInformedClient[skres.Job](t, kt.Create, func(k8s *fake.Clientset) {
-			client := sk.NewClient(context.Background(), k8s)
+			client.Config(context.Background(), k8s)
 
-			query := client.NamespacedQuery("default").
+			query := client.InNamespace("default").
 				Job().
 				Create(new)
 			err := query.Run()
@@ -44,9 +45,9 @@ func TestJobCreate(t *testing.T) {
 		kt.WithInformedClient[skres.Job](t, kt.Create, func(k8s *fake.Clientset) {
 			hasCallbackRun := false
 			baseKubeActions := 2
-			client := sk.NewClient(context.Background(), k8s)
+			client.Config(context.Background(), k8s)
 
-			query := client.NamespacedQuery("default").
+			query := client.InNamespace("default").
 				Job().
 				Create(new).
 				DataHandler(func(job *batch.Job) error {
@@ -64,9 +65,9 @@ func TestJobCreate(t *testing.T) {
 	})
 	t.Run("should cancel execution on callback error", func(t *testing.T) {
 		k8s := fake.NewSimpleClientset()
-		client := sk.NewClient(context.Background(), k8s)
+		client.Config(context.Background(), k8s)
 
-		query := client.NamespacedQuery("default").
+		query := client.InNamespace("default").
 			Job().
 			Create(new).
 			DataHandler(func(*batch.Job) error {
@@ -81,6 +82,7 @@ func TestJobCreate(t *testing.T) {
 }
 
 func TestJobUpdate(t *testing.T) {
+	client := sk.Client{}
 	old := &batch.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-job",
@@ -110,9 +112,9 @@ func TestJobUpdate(t *testing.T) {
 	}
 	t.Run("should success without errors", func(t *testing.T) {
 		kt.WithInformedClient[skres.Job](t, kt.Update, func(k8s *fake.Clientset) {
-			client := sk.NewClient(context.Background(), k8s)
+			client.Config(context.Background(), k8s)
 
-			query := client.NamespacedQuery("default").
+			query := client.InNamespace("default").
 				Job().
 				Update(new)
 
@@ -125,9 +127,9 @@ func TestJobUpdate(t *testing.T) {
 		kt.WithInformedClient[skres.Job](t, kt.Update, func(k8s *fake.Clientset) {
 			hasCallbackRun := false
 			baseKubeActions := 2 // kube fake clients with informers starts with 2 actions
-			client := sk.NewClient(context.Background(), k8s)
+			client.Config(context.Background(), k8s)
 
-			query := client.NamespacedQuery("default").
+			query := client.InNamespace("default").
 				Job().
 				Update(new).
 				DataHandler(func(job *batch.Job) error {
@@ -145,9 +147,9 @@ func TestJobUpdate(t *testing.T) {
 	})
 	t.Run("should cancel execution on callback error", func(t *testing.T) {
 		k8s := fake.NewSimpleClientset(old)
-		client := sk.NewClient(context.Background(), k8s)
+		client.Config(context.Background(), k8s)
 
-		query := client.NamespacedQuery("default").
+		query := client.InNamespace("default").
 			Job().
 			Update(new).
 			DataHandler(func(*batch.Job) error {
@@ -161,6 +163,7 @@ func TestJobUpdate(t *testing.T) {
 }
 
 func TestJobGet(t *testing.T) {
+	client := sk.Client{}
 	kubeDeployment := &batch.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-job",
@@ -188,10 +191,10 @@ func TestJobGet(t *testing.T) {
 			},
 		},
 	}
-	client := sk.NewClient(context.Background(), fake.NewSimpleClientset(kubeDeployment))
+	client.Config(context.Background(), fake.NewSimpleClientset(kubeDeployment))
 
 	t.Run("should return custom error when not found", func(t *testing.T) {
-		query := client.NamespacedQuery("default").
+		query := client.InNamespace("default").
 			Job().
 			Get("not-found")
 		_, err := query.Run()
@@ -199,7 +202,7 @@ func TestJobGet(t *testing.T) {
 		assert.Equal(t, skerr.ERROR_NOT_FOUND, err.Error())
 	})
 	t.Run("should return expected object", func(t *testing.T) {
-		query := client.NamespacedQuery("default").
+		query := client.InNamespace("default").
 			Job().
 			Get("my-job")
 		result, err := query.Run()
@@ -208,7 +211,7 @@ func TestJobGet(t *testing.T) {
 		assert.Equal(t, expected, result)
 	})
 	t.Run("should run DataHandler callback", func(t *testing.T) {
-		query := client.NamespacedQuery("default").
+		query := client.InNamespace("default").
 			Job().
 			Get("my-job").
 			DataHandler(func(job *batch.Job) error {
@@ -221,7 +224,7 @@ func TestJobGet(t *testing.T) {
 		assert.Equal(t, "overrided", result.Containers[0].Image)
 	})
 	t.Run("should cancel execution on callback error", func(t *testing.T) {
-		query := client.NamespacedQuery("default").
+		query := client.InNamespace("default").
 			Job().
 			Get("my-job").
 			DataHandler(func(*batch.Job) error {
@@ -234,6 +237,7 @@ func TestJobGet(t *testing.T) {
 }
 
 func TestJobList(t *testing.T) {
+	client := sk.Client{}
 	job1 := &batch.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-job",
@@ -278,13 +282,13 @@ func TestJobList(t *testing.T) {
 		},
 	}
 
-	client := sk.NewClient(
+	client.Config(
 		context.Background(),
 		fake.NewSimpleClientset(job1, job2),
 	)
 
 	t.Run("should return expected objects", func(t *testing.T) {
-		query := client.NamespacedQuery("default").
+		query := client.InNamespace("default").
 			Job().
 			List()
 		result, err := query.Run()
@@ -293,7 +297,7 @@ func TestJobList(t *testing.T) {
 		assert.Equal(t, 2, len(result))
 	})
 	t.Run("should filter by label", func(t *testing.T) {
-		query := client.NamespacedQuery("default").
+		query := client.InNamespace("default").
 			Job().
 			List().
 			FilterByLabels(map[string]string{
@@ -307,6 +311,7 @@ func TestJobList(t *testing.T) {
 }
 
 func TestJobDelete(t *testing.T) {
+	client := sk.Client{}
 	job := &batch.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-job",
@@ -331,9 +336,9 @@ func TestJobDelete(t *testing.T) {
 	}
 	t.Run("should return no errors when calling delete on an object", func(t *testing.T) {
 		k8s := fake.NewSimpleClientset(job)
-		client := sk.NewClient(context.Background(), k8s)
+		client.Config(context.Background(), k8s)
 
-		query := client.NamespacedQuery("default").
+		query := client.InNamespace("default").
 			Job().
 			Delete("my-job")
 

--- a/tests/namespaced/jobs_test.go
+++ b/tests/namespaced/jobs_test.go
@@ -49,9 +49,8 @@ func TestJobCreate(t *testing.T) {
 			query := client.NamespacedQuery("default").
 				Job().
 				Create(new).
-				DataHandler(func(res interface{}) error {
-					obj := res.(*batch.Job)
-					assert.Equal(t, new.Name, obj.Name)
+				DataHandler(func(job *batch.Job) error {
+					assert.Equal(t, new.Name, job.Name)
 					assert.Equal(t, baseKubeActions, len(k8s.Actions()))
 					hasCallbackRun = true
 					return nil
@@ -70,7 +69,7 @@ func TestJobCreate(t *testing.T) {
 		query := client.NamespacedQuery("default").
 			Job().
 			Create(new).
-			DataHandler(func(res interface{}) error {
+			DataHandler(func(*batch.Job) error {
 				return errors.New("test error")
 			})
 		err := query.Run()
@@ -131,9 +130,8 @@ func TestJobUpdate(t *testing.T) {
 			query := client.NamespacedQuery("default").
 				Job().
 				Update(new).
-				DataHandler(func(res interface{}) error {
-					obj := res.(*batch.Job)
-					assert.Equal(t, new.Name, obj.Name)
+				DataHandler(func(job *batch.Job) error {
+					assert.Equal(t, new.Name, job.Name)
 					assert.Equal(t, baseKubeActions, len(k8s.Actions()))
 					hasCallbackRun = true
 					return nil
@@ -152,7 +150,7 @@ func TestJobUpdate(t *testing.T) {
 		query := client.NamespacedQuery("default").
 			Job().
 			Update(new).
-			DataHandler(func(res interface{}) error {
+			DataHandler(func(*batch.Job) error {
 				return errors.New("test error")
 			})
 		err := query.Run()
@@ -213,8 +211,7 @@ func TestJobGet(t *testing.T) {
 		query := client.NamespacedQuery("default").
 			Job().
 			Get("my-job").
-			DataHandler(func(res interface{}) error {
-				job := res.(*batch.Job)
+			DataHandler(func(job *batch.Job) error {
 				job.Spec.Template.Spec.Containers[0].Image = "overrided"
 				return nil
 			})
@@ -227,7 +224,7 @@ func TestJobGet(t *testing.T) {
 		query := client.NamespacedQuery("default").
 			Job().
 			Get("my-job").
-			DataHandler(func(interface{}) error {
+			DataHandler(func(*batch.Job) error {
 				return errors.New("test error")
 			})
 		_, err := query.Run()

--- a/tests/namespaced/service_test.go
+++ b/tests/namespaced/service_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 func TestServiceCreate(t *testing.T) {
+	client := sk.Client{}
 	new := skres.Service{
 		Name: "my-svc",
 		Port: 80,
@@ -27,9 +28,9 @@ func TestServiceCreate(t *testing.T) {
 
 	t.Run("should success without errors", func(t *testing.T) {
 		kt.WithInformedClient[skres.Service](t, kt.Create, func(k8s *fake.Clientset) {
-			client := sk.NewClient(context.Background(), k8s)
+			client.Config(context.Background(), k8s)
 
-			query := client.NamespacedQuery("default").
+			query := client.InNamespace("default").
 				Service().
 				Create(new)
 			err := query.Run()
@@ -41,9 +42,9 @@ func TestServiceCreate(t *testing.T) {
 		kt.WithInformedClient[skres.Service](t, kt.Create, func(k8s *fake.Clientset) {
 			hasCallbackRun := false
 			baseKubeActions := 2
-			client := sk.NewClient(context.Background(), k8s)
+			client.Config(context.Background(), k8s)
 
-			query := client.NamespacedQuery("default").
+			query := client.InNamespace("default").
 				Service().
 				Create(new).
 				DataHandler(func(svc *api.Service) error {
@@ -60,10 +61,11 @@ func TestServiceCreate(t *testing.T) {
 		})
 	})
 	t.Run("should cancel execution on callback error", func(t *testing.T) {
+		client := sk.Client{}
 		k8s := fake.NewSimpleClientset()
-		client := sk.NewClient(context.Background(), k8s)
+		client.Config(context.Background(), k8s)
 
-		query := client.NamespacedQuery("default").
+		query := client.InNamespace("default").
 			Service().
 			Create(new).
 			DataHandler(func(*api.Service) error {
@@ -78,6 +80,7 @@ func TestServiceCreate(t *testing.T) {
 }
 
 func TestServiceUpdate(t *testing.T) {
+	client := sk.Client{}
 	old := &api.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-svc",
@@ -103,9 +106,9 @@ func TestServiceUpdate(t *testing.T) {
 	}
 	t.Run("should success without errors", func(t *testing.T) {
 		kt.WithInformedClient[skres.Service](t, kt.Update, func(k8s *fake.Clientset) {
-			client := sk.NewClient(context.Background(), k8s)
+			client.Config(context.Background(), k8s)
 
-			query := client.NamespacedQuery("default").
+			query := client.InNamespace("default").
 				Service().
 				Update(new)
 
@@ -118,9 +121,9 @@ func TestServiceUpdate(t *testing.T) {
 		kt.WithInformedClient[skres.Service](t, kt.Update, func(k8s *fake.Clientset) {
 			hasCallbackRun := false
 			baseKubeActions := 2 // kube fake clients with informers starts with 2 actions
-			client := sk.NewClient(context.Background(), k8s)
+			client.Config(context.Background(), k8s)
 
-			query := client.NamespacedQuery("default").
+			query := client.InNamespace("default").
 				Service().
 				Update(new).
 				DataHandler(func(svc *api.Service) error {
@@ -138,9 +141,9 @@ func TestServiceUpdate(t *testing.T) {
 	})
 	t.Run("should cancel execution on callback error", func(t *testing.T) {
 		k8s := fake.NewSimpleClientset(old)
-		client := sk.NewClient(context.Background(), k8s)
+		client.Config(context.Background(), k8s)
 
-		query := client.NamespacedQuery("default").
+		query := client.InNamespace("default").
 			Service().
 			Update(new).
 			DataHandler(func(*api.Service) error {
@@ -154,6 +157,7 @@ func TestServiceUpdate(t *testing.T) {
 }
 
 func TestServiceGet(t *testing.T) {
+	client := sk.Client{}
 	kubeSvc := &api.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-svc",
@@ -177,10 +181,10 @@ func TestServiceGet(t *testing.T) {
 			"app": "nginx",
 		},
 	}
-	client := sk.NewClient(context.Background(), fake.NewSimpleClientset(kubeSvc))
+	client.Config(context.Background(), fake.NewSimpleClientset(kubeSvc))
 
 	t.Run("should return custom error when not found", func(t *testing.T) {
-		query := client.NamespacedQuery("default").
+		query := client.InNamespace("default").
 			Service().
 			Get("not-found")
 		_, err := query.Run()
@@ -188,7 +192,7 @@ func TestServiceGet(t *testing.T) {
 		assert.Equal(t, skerr.ERROR_NOT_FOUND, err.Error())
 	})
 	t.Run("should return expected object", func(t *testing.T) {
-		query := client.NamespacedQuery("default").
+		query := client.InNamespace("default").
 			Service().
 			Get("my-svc")
 		result, err := query.Run()
@@ -197,7 +201,7 @@ func TestServiceGet(t *testing.T) {
 		assert.Equal(t, expected, result)
 	})
 	t.Run("should run DataHandler callback", func(t *testing.T) {
-		query := client.NamespacedQuery("default").
+		query := client.InNamespace("default").
 			Service().
 			Get("my-svc").
 			DataHandler(func(svc *api.Service) error {
@@ -210,7 +214,7 @@ func TestServiceGet(t *testing.T) {
 		assert.Equal(t, 81, result.Port)
 	})
 	t.Run("should cancel execution on callback error", func(t *testing.T) {
-		query := client.NamespacedQuery("default").
+		query := client.InNamespace("default").
 			Service().
 			Get("my-svc").
 			DataHandler(func(*api.Service) error {
@@ -223,6 +227,7 @@ func TestServiceGet(t *testing.T) {
 }
 
 func TestServiceList(t *testing.T) {
+	client := sk.Client{}
 	dpl1 := &api.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-svc",
@@ -263,10 +268,10 @@ func TestServiceList(t *testing.T) {
 		},
 	}
 
-	client := sk.NewClient(context.Background(), fake.NewSimpleClientset(dpl1, dpl2))
+	client.Config(context.Background(), fake.NewSimpleClientset(dpl1, dpl2))
 
 	t.Run("should return expected objects", func(t *testing.T) {
-		query := client.NamespacedQuery("default").
+		query := client.InNamespace("default").
 			Service().
 			List()
 		result, err := query.Run()
@@ -275,7 +280,7 @@ func TestServiceList(t *testing.T) {
 		assert.Equal(t, 2, len(result))
 	})
 	t.Run("should filter by label", func(t *testing.T) {
-		query := client.NamespacedQuery("default").
+		query := client.InNamespace("default").
 			Service().
 			List().
 			FilterByLabels(map[string]string{
@@ -289,6 +294,7 @@ func TestServiceList(t *testing.T) {
 }
 
 func TestServiceDelete(t *testing.T) {
+	client := sk.Client{}
 	dpl := &api.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-svc",
@@ -311,9 +317,9 @@ func TestServiceDelete(t *testing.T) {
 	}
 	t.Run("should return no errors when calling delete on an object", func(t *testing.T) {
 		k8s := fake.NewSimpleClientset(dpl)
-		client := sk.NewClient(context.Background(), k8s)
+		client.Config(context.Background(), k8s)
 
-		query := client.NamespacedQuery("default").
+		query := client.InNamespace("default").
 			Service().
 			Delete("my-svc")
 

--- a/tests/namespaced/service_test.go
+++ b/tests/namespaced/service_test.go
@@ -46,9 +46,8 @@ func TestServiceCreate(t *testing.T) {
 			query := client.NamespacedQuery("default").
 				Service().
 				Create(new).
-				DataHandler(func(res interface{}) error {
-					obj := res.(*api.Service)
-					assert.Equal(t, new.Name, obj.Name)
+				DataHandler(func(svc *api.Service) error {
+					assert.Equal(t, new.Name, svc.Name)
 					assert.Equal(t, baseKubeActions, len(k8s.Actions()))
 					hasCallbackRun = true
 					return nil
@@ -67,7 +66,7 @@ func TestServiceCreate(t *testing.T) {
 		query := client.NamespacedQuery("default").
 			Service().
 			Create(new).
-			DataHandler(func(res interface{}) error {
+			DataHandler(func(*api.Service) error {
 				return errors.New("test error")
 			})
 		err := query.Run()
@@ -124,9 +123,8 @@ func TestServiceUpdate(t *testing.T) {
 			query := client.NamespacedQuery("default").
 				Service().
 				Update(new).
-				DataHandler(func(res interface{}) error {
-					obj := res.(*api.Service)
-					assert.Equal(t, new.Name, obj.Name)
+				DataHandler(func(svc *api.Service) error {
+					assert.Equal(t, new.Name, svc.Name)
 					assert.Equal(t, baseKubeActions, len(k8s.Actions()))
 					hasCallbackRun = true
 					return nil
@@ -145,7 +143,7 @@ func TestServiceUpdate(t *testing.T) {
 		query := client.NamespacedQuery("default").
 			Service().
 			Update(new).
-			DataHandler(func(res interface{}) error {
+			DataHandler(func(*api.Service) error {
 				return errors.New("test error")
 			})
 		err := query.Run()
@@ -202,8 +200,7 @@ func TestServiceGet(t *testing.T) {
 		query := client.NamespacedQuery("default").
 			Service().
 			Get("my-svc").
-			DataHandler(func(res interface{}) error {
-				svc := res.(*api.Service)
+			DataHandler(func(svc *api.Service) error {
 				svc.Spec.Ports[0].Port = 81 // override
 				return nil
 			})
@@ -216,7 +213,7 @@ func TestServiceGet(t *testing.T) {
 		query := client.NamespacedQuery("default").
 			Service().
 			Get("my-svc").
-			DataHandler(func(interface{}) error {
+			DataHandler(func(*api.Service) error {
 				return errors.New("test error")
 			})
 		_, err := query.Run()


### PR DESCRIPTION
## Changes

- Structs used to represent kubernetes resources now are data types without behaviour 

## Breaking

- Actions that support DataHandler now pass the right resource type and not `interface{}` type into callback
- Client now supports directly querying cluster scoped resources (eg: `client.Namespace().Get("my-ns").Run()`
- Changed the way namespace scoped resources is accessed (eg: `client.InNamespace("my-ns").Deployment()...`